### PR TITLE
feat(#42): RoomAllocationPayloadBuilder — Serialização do modelo relacional para OR-Tools

### DIFF
--- a/app/Services/RoomAllocationPayloadBuilder.php
+++ b/app/Services/RoomAllocationPayloadBuilder.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Fusion;
+use App\Models\SchoolClass;
+use App\Models\SchoolTerm;
+use Illuminate\Support\Collection;
+
+class RoomAllocationPayloadBuilder
+{
+    /**
+     * Retorna o schema version esperado pelo solver.
+     */
+    public static function schemaVersion(): string
+    {
+        return '1.0.0';
+    }
+
+    /**
+     * Constroi o payload JSON para o microservico Python OR-Tools.
+     *
+     * @param SchoolTerm $schoolTerm Semestre letivo alvo.
+     * @param array<int> $roomIds IDs das salas disponiveis para alocacao.
+     * @param array<string, mixed> $overrides Sobrescritas para o bloco config (opcional).
+     * @return array<string, mixed> Array estruturado pronto para json_encode.
+     */
+    public function build(SchoolTerm $schoolTerm, array $roomIds, array $overrides = []): array
+    {
+        $allClasses = SchoolClass::whereBelongsTo($schoolTerm)
+            ->with(['classschedules', 'fusion'])
+            ->orderBy('id')
+            ->get();
+
+        $canonical = $this->canonicalize($allClasses);
+
+        $groups = $this->resolveGroups($canonical);
+
+        $timeslots = $this->buildTimeslotCatalog($groups);
+
+        $timeslotIndexMap = [];
+        foreach ($timeslots as $index => $ts) {
+            $timeslotIndexMap[$ts['label']] = $index;
+        }
+
+        $finalGroups = [];
+        foreach ($groups as $group) {
+            $group['timeslot_ids'] = array_map(
+                fn ($label) => $timeslotIndexMap[$label],
+                $group['timeslot_labels']
+            );
+            sort($group['timeslot_ids']);
+            unset($group['timeslot_labels']);
+            $finalGroups[] = $group;
+        }
+
+        usort($finalGroups, fn ($a, $b) => $a['id'] <=> $b['id']);
+
+        $rooms = \App\Models\Room::whereIn('id', $roomIds)
+            ->orderBy('id')
+            ->get()
+            ->map(fn ($room) => [
+                'id' => $room->id,
+                'name' => $room->nome,
+                'capacity' => $room->assentos,
+            ])
+            ->values()
+            ->all();
+
+        return [
+            'meta' => $this->buildMeta($schoolTerm),
+            'config' => $this->buildConfig($overrides),
+            'timeslots' => $timeslots,
+            'rooms' => $rooms,
+            'groups' => $finalGroups,
+        ];
+    }
+
+    /**
+     * Aplica filtros de escopo e ordenacao deterministica.
+     *
+     * @param Collection $classes
+     * @return Collection
+     */
+    private function canonicalize(Collection $classes): Collection
+    {
+        return $classes
+            ->reject(fn ($class) => $class->externa)
+            ->reject(fn ($class) => $class->coddis === 'MAE0116')
+            ->sortBy('id')
+            ->values();
+    }
+
+    /**
+     * Agrupa turmas por fusion_id. Turmas sem fusao viram grupos solo.
+     *
+     * @param Collection $schoolClasses
+     * @return array
+     */
+    private function resolveGroups(Collection $schoolClasses): array
+    {
+        $solo = $schoolClasses->whereNull('fusion_id');
+        $fused = $schoolClasses->whereNotNull('fusion_id')->groupBy('fusion_id');
+
+        $groups = [];
+
+        foreach ($solo as $class) {
+            $groups[] = $this->buildSingleGroup([$class], null);
+        }
+
+        foreach ($fused as $fusionId => $classes) {
+            $fusion = $classes->first()->fusion;
+            $groups[] = $this->buildSingleGroup($classes->all(), $fusion);
+        }
+
+        return $groups;
+    }
+
+    /**
+     * Constroi o descriptor de um grupo (single ou fusion).
+     *
+     * @param array $classes
+     * @param Fusion|null $fusion
+     * @return array
+     */
+    private function buildSingleGroup(array $classes, ?Fusion $fusion): array
+    {
+        usort($classes, fn ($a, $b) => $a->id <=> $b->id);
+
+        $classIds = array_map(fn ($c) => $c->id, $classes);
+        $representative = $classes[0];
+
+        $tiptur = 'Pós Graduação';
+        foreach ($classes as $class) {
+            if ($class->tiptur === 'Graduação') {
+                $tiptur = 'Graduação';
+                break;
+            }
+        }
+
+        $estmtrs = array_map(fn ($c) => $c->estmtr, $classes);
+        $hasNull = in_array(null, $estmtrs, true);
+        $validEstmtrs = array_filter($estmtrs, fn ($v) => $v !== null);
+        $demand = array_sum($validEstmtrs);
+
+        $timeslotLabels = [];
+        foreach ($classes as $class) {
+            foreach ($class->classschedules as $schedule) {
+                $label = $this->timeslotToLabel(
+                    $schedule->diasmnocp,
+                    $schedule->horent,
+                    $schedule->horsai
+                );
+                $timeslotLabels[$label] = true;
+            }
+        }
+        $timeslotLabels = array_keys($timeslotLabels);
+        sort($timeslotLabels);
+
+        $groupId = $fusion && $fusion->master_id ? $fusion->master_id : min($classIds);
+
+        return [
+            'id' => $groupId,
+            'type' => $fusion ? 'fusion' : 'single',
+            'class_ids' => $classIds,
+            'coddis' => $representative->coddis,
+            'codtur' => $representative->codtur,
+            'nomdis' => $representative->nomdis,
+            'tiptur' => $tiptur,
+            'demand' => $demand,
+            'has_null_enrollment' => $hasNull,
+            'timeslot_labels' => $timeslotLabels,
+            'preassigned_room_id' => null,
+        ];
+    }
+
+    /**
+     * Constroi o catalogo global de timeslots unicos.
+     *
+     * @param array $groups
+     * @return array
+     */
+    private function buildTimeslotCatalog(array $groups): array
+    {
+        $labels = [];
+        foreach ($groups as $group) {
+            foreach ($group['timeslot_labels'] as $label) {
+                $labels[$label] = true;
+            }
+        }
+
+        $allLabels = array_keys($labels);
+        sort($allLabels);
+
+        $timeslots = [];
+        foreach ($allLabels as $index => $label) {
+            $parts = explode('_', $label);
+            $timeslots[] = [
+                'id' => $index,
+                'label' => $label,
+                'day' => $parts[0],
+                'start' => substr($parts[1], 0, 2) . ':' . substr($parts[1], 2, 2),
+                'end' => substr($parts[2], 0, 2) . ':' . substr($parts[2], 2, 2),
+            ];
+        }
+
+        return $timeslots;
+    }
+
+    /**
+     * Canoniza um horario em label string deterministico.
+     *
+     * @param string $day
+     * @param string $start
+     * @param string $end
+     * @return string
+     */
+    private function timeslotToLabel(string $day, string $start, string $end): string
+    {
+        $startClean = str_replace(':', '', $start);
+        $endClean = str_replace(':', '', $end);
+        return "{$day}_{$startClean}_{$endClean}";
+    }
+
+    /**
+     * Monta o bloco de configuracao do solver.
+     *
+     * @param array $overrides
+     * @return array
+     */
+    private function buildConfig(array $overrides): array
+    {
+        $defaults = config('alocacao.room_allocation', []);
+        return array_merge($defaults, $overrides);
+    }
+
+    /**
+     * Monta o bloco de metadados do payload.
+     *
+     * @param SchoolTerm $schoolTerm
+     * @return array
+     */
+    private function buildMeta(SchoolTerm $schoolTerm): array
+    {
+        return [
+            'version' => self::schemaVersion(),
+            'school_term_id' => $schoolTerm->id,
+            'generated_at' => now()->toIso8601String(),
+            'builder_class' => self::class,
+        ];
+    }
+}

--- a/config/alocacao.php
+++ b/config/alocacao.php
@@ -24,4 +24,17 @@ return [
     |--------------------------------------------------------------------------
     */
     'historical_min_years' => (int) env('HISTORICAL_MIN_YEARS', 2),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Configurações do solver de alocação de salas (OR-Tools Python).
+    |--------------------------------------------------------------------------
+    */
+    'room_allocation' => [
+        'strict_capacity' => (bool) env('ROOM_ALLOCATION_STRICT_CAPACITY', false),
+        'block_b_restriction_for_pos' => (bool) env('ROOM_ALLOCATION_BLOCK_B_POS', true),
+        'wasted_seats_weight' => (float) env('ROOM_ALLOCATION_WASTED_SEATS_WEIGHT', 1.0),
+        'unassigned_penalty' => (float) env('ROOM_ALLOCATION_UNASSIGNED_PENALTY', 1000.0),
+        'priority_weight' => (float) env('ROOM_ALLOCATION_PRIORITY_WEIGHT', 0.0),
+    ],
 ];

--- a/database/factories/ClassScheduleFactory.php
+++ b/database/factories/ClassScheduleFactory.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ClassSchedule;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ClassScheduleFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = ClassSchedule::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        $days = ['seg', 'ter', 'qua', 'qui', 'sex'];
+        $day = $this->faker->randomElement($days);
+
+        $startHour = $this->faker->numberBetween(8, 16);
+        $startMinute = $this->faker->randomElement(['00', '40']);
+        $start = sprintf('%02d:%s', $startHour, $startMinute);
+
+        $endHour = $startHour + 2;
+        $endMinute = $startMinute;
+        $end = sprintf('%02d:%s', $endHour, $endMinute);
+
+        return [
+            'diasmnocp' => $day,
+            'horent' => $start,
+            'horsai' => $end,
+        ];
+    }
+
+    public function seg()
+    {
+        return $this->state(['diasmnocp' => 'seg']);
+    }
+
+    public function ter()
+    {
+        return $this->state(['diasmnocp' => 'ter']);
+    }
+
+    public function qua()
+    {
+        return $this->state(['diasmnocp' => 'qua']);
+    }
+
+    public function qui()
+    {
+        return $this->state(['diasmnocp' => 'qui']);
+    }
+
+    public function sex()
+    {
+        return $this->state(['diasmnocp' => 'sex']);
+    }
+
+    public function morning()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'horent' => '08:00',
+                'horsai' => '10:00',
+            ];
+        });
+    }
+
+    public function afternoon()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'horent' => '14:00',
+                'horsai' => '16:00',
+            ];
+        });
+    }
+}

--- a/database/factories/FusionFactory.php
+++ b/database/factories/FusionFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Fusion;
+use App\Models\SchoolClass;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class FusionFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Fusion::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'master_id' => null,
+        ];
+    }
+
+    /**
+     * Configure the model factory with a specific master class.
+     *
+     * @param SchoolClass $schoolClass
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function withMaster(SchoolClass $schoolClass)
+    {
+        return $this->state(function (array $attributes) use ($schoolClass) {
+            return [
+                'master_id' => $schoolClass->id,
+            ];
+        });
+    }
+}

--- a/tests/Unit/RoomAllocationPayloadBuilderTest.php
+++ b/tests/Unit/RoomAllocationPayloadBuilderTest.php
@@ -1,0 +1,361 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Services\RoomAllocationPayloadBuilder;
+use App\Models\SchoolClass;
+use App\Models\SchoolTerm;
+use App\Models\Room;
+use App\Models\Fusion;
+use App\Models\ClassSchedule;
+
+class RoomAllocationPayloadBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_builds_payload_for_single_class_with_schedule()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'coddis' => 'MAC0110',
+            'codtur' => '20241',
+            'nomdis' => 'Introducao a Computacao',
+            'tiptur' => 'Graduacao',
+            'estmtr' => 55,
+            'externa' => false,
+            'fusion_id' => null,
+        ]);
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $this->assertCount(1, $payload['groups']);
+        $group = $payload['groups'][0];
+        $this->assertEquals($class->id, $group['id']);
+        $this->assertEquals('single', $group['type']);
+        $this->assertEquals([$class->id], $group['class_ids']);
+        $this->assertEquals('MAC0110', $group['coddis']);
+        $this->assertEquals(55, $group['demand']);
+        $this->assertFalse($group['has_null_enrollment']);
+        $this->assertCount(1, $group['timeslot_ids']);
+        $this->assertEquals(0, $group['timeslot_ids'][0]);
+        $this->assertNull($group['preassigned_room_id']);
+    }
+
+    /** @test */
+    public function it_builds_payload_for_fusion_with_two_classes()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $fusion = Fusion::factory()->create();
+        $classA = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'coddis' => 'MAT2453',
+            'codtur' => '20241',
+            'nomdis' => 'Calculo Diferencial e Integral I',
+            'tiptur' => 'Graduacao',
+            'estmtr' => 60,
+            'fusion_id' => $fusion->id,
+        ]);
+        $classB = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'coddis' => 'MAT2453',
+            'codtur' => '20242',
+            'nomdis' => 'Calculo Diferencial e Integral I',
+            'tiptur' => 'Graduacao',
+            'estmtr' => 60,
+            'fusion_id' => $fusion->id,
+        ]);
+
+        $schedule1 = ClassSchedule::factory()->seg()->morning()->create();
+        $schedule2 = ClassSchedule::factory()->ter()->morning()->create();
+        $classA->classschedules()->attach([$schedule1->id, $schedule2->id]);
+        $classB->classschedules()->attach([$schedule2->id]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $this->assertCount(1, $payload['groups']);
+        $group = $payload['groups'][0];
+        $this->assertEquals('fusion', $group['type']);
+        $this->assertEquals([$classA->id, $classB->id], $group['class_ids']);
+        $this->assertEquals(120, $group['demand']);
+        $this->assertCount(2, $group['timeslot_ids']);
+    }
+
+    /** @test */
+    public function it_builds_payload_for_fusion_with_partial_null_enrollment()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $fusion = Fusion::factory()->create();
+        $classA = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'estmtr' => 40,
+            'fusion_id' => $fusion->id,
+        ]);
+        $classB = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'estmtr' => null,
+            'fusion_id' => $fusion->id,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertTrue($group['has_null_enrollment']);
+        $this->assertEquals(40, $group['demand']);
+    }
+
+    /** @test */
+    public function it_excludes_external_classes()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $external = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'externa' => true,
+        ]);
+        $normal = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'externa' => false,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $classIds = array_column($payload['groups'], 'id');
+        $this->assertNotContains($external->id, $classIds);
+        $this->assertContains($normal->id, $classIds);
+    }
+
+    /** @test */
+    public function it_excludes_mae0116()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $excluded = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'coddis' => 'MAE0116',
+        ]);
+        $normal = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'coddis' => 'MAC0110',
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $classIds = array_column($payload['groups'], 'id');
+        $this->assertNotContains($excluded->id, $classIds);
+        $this->assertContains($normal->id, $classIds);
+    }
+
+    /** @test */
+    public function it_only_includes_specified_rooms()
+    {
+        $term = SchoolTerm::factory()->create();
+        $roomA = Room::factory()->create();
+        $roomB = Room::factory()->create();
+        $roomC = Room::factory()->create();
+
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$roomA->id, $roomC->id]);
+
+        $roomIds = array_column($payload['rooms'], 'id');
+        $this->assertEquals([$roomA->id, $roomC->id], $roomIds);
+        $this->assertNotContains($roomB->id, $roomIds);
+    }
+
+    /** @test */
+    public function it_generates_unique_timeslots()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $classA = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+        ]);
+        $classB = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+        ]);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $classA->classschedules()->attach($schedule);
+        $classB->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $this->assertCount(1, $payload['timeslots']);
+        $this->assertEquals('seg_0800_1000', $payload['timeslots'][0]['label']);
+        $this->assertEquals('seg', $payload['timeslots'][0]['day']);
+        $this->assertEquals('08:00', $payload['timeslots'][0]['start']);
+        $this->assertEquals('10:00', $payload['timeslots'][0]['end']);
+    }
+
+    /** @test */
+    public function it_produces_deterministic_output()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        SchoolClass::factory()->count(5)->create([
+            'school_term_id' => $term->id,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload1 = $builder->build($term, [$room->id]);
+        $payload2 = $builder->build($term, [$room->id]);
+
+        // Reset generated_at before comparison
+        $payload1['meta']['generated_at'] = '';
+        $payload2['meta']['generated_at'] = '';
+
+        $this->assertEquals($payload1, $payload2);
+    }
+
+    /** @test */
+    public function it_includes_config_block_with_defaults()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $this->assertArrayHasKey('config', $payload);
+        $this->assertArrayHasKey('strict_capacity', $payload['config']);
+        $this->assertArrayHasKey('block_b_restriction_for_pos', $payload['config']);
+        $this->assertArrayHasKey('wasted_seats_weight', $payload['config']);
+        $this->assertArrayHasKey('unassigned_penalty', $payload['config']);
+        $this->assertArrayHasKey('priority_weight', $payload['config']);
+
+        $this->assertFalse($payload['config']['strict_capacity']);
+        $this->assertTrue($payload['config']['block_b_restriction_for_pos']);
+        $this->assertEquals(1.0, $payload['config']['wasted_seats_weight']);
+        $this->assertEquals(1000.0, $payload['config']['unassigned_penalty']);
+        $this->assertEquals(0.0, $payload['config']['priority_weight']);
+    }
+
+    /** @test */
+    public function it_overrides_config_values()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id], [
+            'strict_capacity' => true,
+            'wasted_seats_weight' => 5.0,
+        ]);
+
+        $this->assertTrue($payload['config']['strict_capacity']);
+        $this->assertEquals(5.0, $payload['config']['wasted_seats_weight']);
+        $this->assertTrue($payload['config']['block_b_restriction_for_pos']);
+    }
+
+    /** @test */
+    public function it_includes_meta_block()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $this->assertArrayHasKey('meta', $payload);
+        $this->assertEquals('1.0.0', $payload['meta']['version']);
+        $this->assertEquals($term->id, $payload['meta']['school_term_id']);
+        $this->assertEquals(RoomAllocationPayloadBuilder::class, $payload['meta']['builder_class']);
+        $this->assertNotEmpty($payload['meta']['generated_at']);
+    }
+
+    /** @test */
+    public function it_handles_class_without_schedules()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertEmpty($group['timeslot_ids']);
+        $this->assertEmpty($payload['timeslots']);
+    }
+
+    /** @test */
+    public function it_does_not_read_priority_data()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $this->assertArrayNotHasKey('priorities', $payload);
+        $this->assertArrayNotHasKey('priority', $payload);
+    }
+
+    /** @test */
+    public function it_handles_fusion_without_master_using_min_id()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $fusion = Fusion::factory()->create(['master_id' => null]);
+        $classA = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'fusion_id' => $fusion->id,
+        ]);
+        $classB = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'fusion_id' => $fusion->id,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $expectedId = min($classA->id, $classB->id);
+        $this->assertEquals($expectedId, $group['id']);
+        $this->assertEquals('fusion', $group['type']);
+    }
+}

--- a/tests/Unit/RoomAllocationPayloadBuilderTest.php
+++ b/tests/Unit/RoomAllocationPayloadBuilderTest.php
@@ -358,4 +358,142 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertEquals($expectedId, $group['id']);
         $this->assertEquals('fusion', $group['type']);
     }
+
+    /** @test */
+    public function it_handles_all_null_enrollment()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $fusion = Fusion::factory()->create();
+        $classA = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'estmtr' => null,
+            'fusion_id' => $fusion->id,
+        ]);
+        $classB = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'estmtr' => null,
+            'fusion_id' => $fusion->id,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertTrue($group['has_null_enrollment']);
+        $this->assertEquals(0, $group['demand']);
+    }
+
+    /** @test */
+    public function it_handles_empty_school_term()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $this->assertEmpty($payload['groups']);
+        $this->assertEmpty($payload['timeslots']);
+        $this->assertCount(1, $payload['rooms']);
+    }
+
+    /** @test */
+    public function it_rejects_all_classes_when_filtered()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $room->id,
+            'externa' => true,
+        ]);
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $room->id,
+            'coddis' => 'MAE0116',
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $this->assertEmpty($payload['groups']);
+        $this->assertEmpty($payload['timeslots']);
+    }
+
+    /** @test */
+    public function it_handles_room_ids_empty_array()
+    {
+        $term = SchoolTerm::factory()->create();
+
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+        ]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, []);
+
+        $this->assertEmpty($payload['rooms']);
+        $this->assertCount(1, $payload['groups']);
+    }
+
+    /** @test */
+    public function it_handles_fusion_with_one_class_having_no_schedules()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $fusion = Fusion::factory()->create();
+        $classA = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'fusion_id' => $fusion->id,
+        ]);
+        $classB = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'fusion_id' => $fusion->id,
+        ]);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $classA->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertCount(1, $group['timeslot_ids']);
+        $this->assertCount(1, $payload['timeslots']);
+    }
+
+    /** @test */
+    public function it_sorts_timeslots_lexicographically()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+        ]);
+
+        $s1 = ClassSchedule::factory()->qui()->afternoon()->create();
+        $s2 = ClassSchedule::factory()->seg()->morning()->create();
+        $s3 = ClassSchedule::factory()->ter()->morning()->create();
+        $class->classschedules()->attach([$s1->id, $s2->id, $s3->id]);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $timeslots = $payload['timeslots'];
+        $this->assertCount(3, $timeslots);
+
+        $labels = array_column($timeslots, 'label');
+        $sorted = $labels;
+        sort($sorted);
+        $this->assertEquals($sorted, $labels);
+
+        $this->assertEquals('qui_1400_1600', $labels[0]);
+        $this->assertEquals('seg_0800_1000', $labels[1]);
+        $this->assertEquals('ter_0800_1000', $labels[2]);
+    }
 }


### PR DESCRIPTION
## Summary

Implementa o `RoomAllocationPayloadBuilder`, serviço responsável por serializar o modelo relacional (SchoolClass, Room, Fusion, ClassSchedule) em um payload JSON determinístico e versionado para o futuro microserviço Python OR-Tools.

## O que foi feito

- **`app/Services/RoomAllocationPayloadBuilder.php`** — Serviço principal com schema v1.0.0
  - Agrupa turmas por `Fusion` em super-turmas (demanda somada, horários unificados/deduplicados)
  - Normaliza `ClassSchedule` em catálogo global de timeslots com referência por índice inteiro
  - Filtros: exclui turmas externas e disciplina `MAE0116`
  - Blocos `meta`, `config`, `timeslots`, `rooms`, `groups` conforme especificação da issue
  - Fallback para `min(class_ids)` quando `fusion.master_id` é nulo

- **`config/alocacao.php`** — Adiciona seção `room_allocation` com 5 parâmetros do solver

- **`database/factories/FusionFactory.php`** — Factory para `Fusion` (estado `withMaster`)

- **`database/factories/ClassScheduleFactory.php`** — Factory para `ClassSchedule` (estados de dia e período)

- **`tests/Unit/RoomAllocationPayloadBuilderTest.php`** — 20 testes unitários cobrindo todos os ACs + edge cases

## Critérios de aceite atendidos

| AC | Status |
|---|---|
| AC1 — Classe versionada | schema `v1.0.0` |
| AC2 — Fusões abstraídas | demanda somada, horários unificados |
| AC3 — Normalização de horários | catálogo `timeslots` com índices |
| AC4 — Filtros de escopo | externas e MAE0116 excluídas |
| AC5 — Prioridades ignoradas | sem dados de Priority no payload |
| AC6 — Bloco config | 5 chaves com defaults |
| AC7 — Testes unitários | 20 testes |
| AC8 — Determinismo | output idêntico para mesmo input |
| AC9 — Documentação interna | PHPDoc em todos os métodos |
| AC10 — Compatibilidade de schema | formato conforme issue |

## Testes

```bash
docker exec alocacao-app php artisan test tests/Unit/RoomAllocationPayloadBuilderTest.php
# 20 passed
```

## Próximos passos

- Issue #41 — `RoomAllocationClient` (HTTP client para o microserviço Python)
- Issue #41 — `RoomAllocationResultApplier` (aplica room_id de volta nas SchoolClass)