### PR TITLE
feat(payload): identifica turmas de mesma coorte (Cohort) no payload do solver

### DIFF
--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -14,5 +14,6 @@ class Course extends Model
         'codcur',
         'perhab',
         'grupo',
+        'sufixo_codtur',
     ];
 }

--- a/app/Services/RoomAllocationPayloadBuilder.php
+++ b/app/Services/RoomAllocationPayloadBuilder.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\Course;
 use App\Models\Fusion;
 use App\Models\SchoolClass;
 use App\Models\SchoolTerm;
@@ -28,13 +29,15 @@ class RoomAllocationPayloadBuilder
     public function build(SchoolTerm $schoolTerm, array $roomIds, array $overrides = []): array
     {
         $allClasses = SchoolClass::whereBelongsTo($schoolTerm)
-            ->with(['classschedules', 'fusion'])
+            ->with(['classschedules', 'fusion', 'courseinformations'])
             ->orderBy('id')
             ->get();
 
         $canonical = $this->canonicalize($allClasses);
 
-        $groups = $this->resolveGroups($canonical);
+        $validSuffixes = Course::all()->pluck('sufixo_codtur')->toArray();
+
+        $groups = $this->resolveGroups($canonical, $validSuffixes);
 
         $timeslots = $this->buildTimeslotCatalog($groups);
 
@@ -97,7 +100,7 @@ class RoomAllocationPayloadBuilder
      * @param Collection $schoolClasses
      * @return array
      */
-    private function resolveGroups(Collection $schoolClasses): array
+    private function resolveGroups(Collection $schoolClasses, array $validSuffixes): array
     {
         $solo = $schoolClasses->whereNull('fusion_id');
         $fused = $schoolClasses->whereNotNull('fusion_id')->groupBy('fusion_id');
@@ -105,12 +108,12 @@ class RoomAllocationPayloadBuilder
         $groups = [];
 
         foreach ($solo as $class) {
-            $groups[] = $this->buildSingleGroup([$class], null);
+            $groups[] = $this->buildSingleGroup([$class], null, $validSuffixes);
         }
 
         foreach ($fused as $fusionId => $classes) {
             $fusion = $classes->first()->fusion;
-            $groups[] = $this->buildSingleGroup($classes->all(), $fusion);
+            $groups[] = $this->buildSingleGroup($classes->all(), $fusion, $validSuffixes);
         }
 
         return $groups;
@@ -123,7 +126,7 @@ class RoomAllocationPayloadBuilder
      * @param Fusion|null $fusion
      * @return array
      */
-    private function buildSingleGroup(array $classes, ?Fusion $fusion): array
+    private function buildSingleGroup(array $classes, ?Fusion $fusion, array $validSuffixes): array
     {
         usort($classes, fn ($a, $b) => $a->id <=> $b->id);
 
@@ -149,6 +152,23 @@ class RoomAllocationPayloadBuilder
 
         $groupId = $fusion && $fusion->master_id ? $fusion->master_id : min($classIds);
 
+        $sameRoomCohort = null;
+
+        if ($tiptur === 'Graduação') {
+            foreach ($classes as $class) {
+                $suffix = substr($class->codtur, -2);
+
+                if (in_array($suffix, $validSuffixes, true)) {
+                    foreach ($class->courseinformations as $ci) {
+                        if ($ci->tipobg === 'O' && in_array($ci->numsemidl, ['1', '2'], true)) {
+                            $sameRoomCohort = "cohort_{$suffix}_sem_{$ci->numsemidl}";
+                            break 2;
+                        }
+                    }
+                }
+            }
+        }
+
         return [
             'id' => $groupId,
             'type' => $fusion ? 'fusion' : 'single',
@@ -161,6 +181,7 @@ class RoomAllocationPayloadBuilder
             'has_null_enrollment' => $hasNull,
             'timeslot_labels' => $timeslotLabels,
             'preassigned_room_id' => null,
+            'same_room_cohort' => $sameRoomCohort,
         ];
     }
 

--- a/database/factories/CourseFactory.php
+++ b/database/factories/CourseFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Course;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CourseFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Course::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'sufixo_codtur' => $this->faker->unique()->numerify('##'),
+            'nomcur' => $this->faker->sentence(3),
+            'perhab' => $this->faker->randomElement(['integral', 'noturno', 'diurno', 'matutino']),
+            'codcur' => $this->faker->numerify('#####'),
+            'grupo' => null,
+        ];
+    }
+}

--- a/database/factories/CourseInformationFactory.php
+++ b/database/factories/CourseInformationFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CourseInformation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CourseInformationFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = CourseInformation::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'nomcur' => $this->faker->sentence(3),
+            'codcur' => $this->faker->numerify('#####'),
+            'numsemidl' => $this->faker->randomElement(['1', '2', '3', '4', '5', '6']),
+            'perhab' => $this->faker->word,
+            'codhab' => $this->faker->numerify('#'),
+            'nomhab' => $this->faker->sentence(2),
+            'tipobg' => $this->faker->randomElement(['O', 'C', 'L']),
+        ];
+    }
+
+    /**
+     * Configure the model factory for mandatory disciplines.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function mandatory()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'tipobg' => 'O',
+            ];
+        });
+    }
+
+    /**
+     * Configure the model factory for a specific ideal semester.
+     *
+     * @param string $semester
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function semester(string $semester)
+    {
+        return $this->state(function (array $attributes) use ($semester) {
+            return [
+                'numsemidl' => $semester,
+            ];
+        });
+    }
+}

--- a/tests/Unit/RoomAllocationPayloadBuilderTest.php
+++ b/tests/Unit/RoomAllocationPayloadBuilderTest.php
@@ -47,6 +47,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertCount(1, $group['timeslot_ids']);
         $this->assertEquals(0, $group['timeslot_ids'][0]);
         $this->assertNull($group['preassigned_room_id']);
+        $this->assertArrayHasKey('same_room_cohort', $group);
+        $this->assertNull($group['same_room_cohort']);
     }
 
     /** @test */
@@ -89,6 +91,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertEquals([$classA->id, $classB->id], $group['class_ids']);
         $this->assertEquals(120, $group['demand']);
         $this->assertCount(2, $group['timeslot_ids']);
+        $this->assertArrayHasKey('same_room_cohort', $group);
+        $this->assertNull($group['same_room_cohort']);
     }
 
     /** @test */
@@ -115,6 +119,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $group = $payload['groups'][0];
         $this->assertTrue($group['has_null_enrollment']);
         $this->assertEquals(40, $group['demand']);
+        $this->assertArrayHasKey('same_room_cohort', $group);
+        $this->assertNull($group['same_room_cohort']);
     }
 
     /** @test */
@@ -315,6 +321,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $group = $payload['groups'][0];
         $this->assertEmpty($group['timeslot_ids']);
         $this->assertEmpty($payload['timeslots']);
+        $this->assertArrayHasKey('same_room_cohort', $group);
+        $this->assertNull($group['same_room_cohort']);
     }
 
     /** @test */
@@ -357,6 +365,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $expectedId = min($classA->id, $classB->id);
         $this->assertEquals($expectedId, $group['id']);
         $this->assertEquals('fusion', $group['type']);
+        $this->assertArrayHasKey('same_room_cohort', $group);
+        $this->assertNull($group['same_room_cohort']);
     }
 
     /** @test */
@@ -383,6 +393,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $group = $payload['groups'][0];
         $this->assertTrue($group['has_null_enrollment']);
         $this->assertEquals(0, $group['demand']);
+        $this->assertArrayHasKey('same_room_cohort', $group);
+        $this->assertNull($group['same_room_cohort']);
     }
 
     /** @test */
@@ -464,6 +476,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $group = $payload['groups'][0];
         $this->assertCount(1, $group['timeslot_ids']);
         $this->assertCount(1, $payload['timeslots']);
+        $this->assertArrayHasKey('same_room_cohort', $group);
+        $this->assertNull($group['same_room_cohort']);
     }
 
     /** @test */
@@ -500,6 +514,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $labels = array_column($payload['timeslots'], 'label');
         $this->assertContains('qua_1400_1600', $labels);
         $this->assertContains('seg_1600_1800', $labels);
+        $this->assertArrayHasKey('same_room_cohort', $group);
+        $this->assertNull($group['same_room_cohort']);
     }
 
     /** @test */
@@ -529,6 +545,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertEquals('fusion', $group['type']);
         $this->assertCount(1, $group['timeslot_ids']);
         $this->assertEquals('ter_0800_1000', $payload['timeslots'][0]['label']);
+        $this->assertArrayHasKey('same_room_cohort', $group);
+        $this->assertNull($group['same_room_cohort']);
     }
 
     /** @test */
@@ -563,6 +581,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $labels = array_column($payload['timeslots'], 'label');
         $this->assertContains('seg_0800_1000', $labels);
         $this->assertContains('ter_0800_1000', $labels);
+        $this->assertArrayHasKey('same_room_cohort', $group);
+        $this->assertNull($group['same_room_cohort']);
     }
 
     /** @test */
@@ -594,5 +614,40 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertEquals('qui_1400_1600', $labels[0]);
         $this->assertEquals('seg_0800_1000', $labels[1]);
         $this->assertEquals('ter_0800_1000', $labels[2]);
+    }
+
+    /** @test */
+    public function it_assigns_same_room_cohort_to_mandatory_initial_semesters()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $course = \App\Models\Course::factory()->create([
+            'sufixo_codtur' => '45',
+        ]);
+
+        $courseInfo = \App\Models\CourseInformation::factory()->create([
+            'tipobg' => 'O',
+            'numsemidl' => '1',
+        ]);
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'codtur' => '202445',
+            'tiptur' => 'Graduação',
+            'externa' => false,
+            'fusion_id' => null,
+        ]);
+
+        $class->courseinformations()->attach($courseInfo);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertEquals('cohort_45_sem_1', $group['same_room_cohort']);
     }
 }


### PR DESCRIPTION
## Resumo

Implementa a identificação de turmas de mesma coorte (Cohort) no payload JSON enviado ao solver Python, conforme definido pela comissão de horários.

Alunos ingressantes (1º e 2º semestres ideais) não devem precisar trocar de sala entre disciplinas obrigatórias da mesma grade. As turmas que compõem a mesma coorte são alocadas fisicamente na **mesma sala** e possuem **prioridade absoluta**.

## O que mudou

- `app/Services/RoomAllocationPayloadBuilder.php`:
  - Adicionado eager loading `with('courseinformations')` na query principal.
  - Carregamento único de sufixos válidos via `Course::all()` fora de loops (evita N+1).
  - Cálculo de `same_room_cohort` iterando sobre **todas** as turmas do grupo, incluindo fusões.
- `app/Models/Course.php`:
  - Adicionado `sufixo_codtur` ao `$fillable`.
- `database/factories/CourseFactory.php` & `database/factories/CourseInformationFactory.php`:
  - Novas factories para suportar testes.
- `tests/Unit/RoomAllocationPayloadBuilderTest.php`:
  - Testes existentes atualizados para prever a chave `same_room_cohort`.
  - Novo teste `it_assigns_same_room_cohort_to_mandatory_initial_semesters`.

## Critérios de Aceite

- [x] Turmas de 1º e 2º semestre obrigatórias recebem a string de cohort corretamente no JSON gerado.
- [x] A tag de cohort só é gerada se o sufixo extraído da turma existir na coluna `sufixo_codtur` da tabela `courses`.
- [x] Turmas de semestres avançados, optativas ou Pós-Graduação recebem `same_room_cohort: null`.
- [x] Query de consulta de cursos e eager loading de `courseinformations` otimizados (sem N+1).

## Issue Relacionada

Closes #46
