### PR TITLE
[Laravel] Atualizar Payload para Suporte a Restrições Direcionais de Blocos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -251,6 +251,16 @@ ALOCACAO_SOLVER_TIMEOUT=60
 # Verificar SSL em ambiente de produção
 ALOCACAO_SOLVER_VERIFY_SSL=true
 
+# RESTRIÇÕES DIRECIONAIS DE BLOCOS (Issue 49)
+# Hard Constraint: protege calouros do IME no Bloco A
+ROOM_ALLOCATION_BLOCK_A_FRESHMEN=true
+
+# Soft Constraint: penalidade ao alocar Graduação no Bloco A
+ROOM_ALLOCATION_UNDERGRAD_BLOCK_A_PENALTY=500.0
+
+# Soft Constraint: penalidade ao alocar Pós-Graduação no Bloco B
+ROOM_ALLOCATION_POS_BLOCK_B_PENALTY=500.0
+
 # TRATAMENTO DE ERROS ######################################
 # Configurações para logging e notificação de problemas
 

--- a/app/Services/RoomAllocationPayloadBuilder.php
+++ b/app/Services/RoomAllocationPayloadBuilder.php
@@ -120,6 +120,37 @@ class RoomAllocationPayloadBuilder
     }
 
     /**
+     * Resolve se o grupo é composto por calouros do IME e retorna
+     * os dados do cohort, se aplicável.
+     *
+     * @param array $classes
+     * @param array $validSuffixes
+     * @return array|null ['suffix' => string, 'semester' => string] ou null
+     */
+    private function resolveFreshmenCohort(array $classes, array $validSuffixes): ?array
+    {
+        foreach ($classes as $class) {
+            if ($class->tiptur !== 'Graduação') {
+                continue;
+            }
+
+            $suffix = substr($class->codtur, -2);
+
+            if (! in_array($suffix, $validSuffixes, true)) {
+                continue;
+            }
+
+            foreach ($class->courseinformations as $ci) {
+                if ($ci->tipobg === 'O' && in_array($ci->numsemidl, ['1', '2'], true)) {
+                    return ['suffix' => $suffix, 'semester' => $ci->numsemidl];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Constroi o descriptor de um grupo (single ou fusion).
      *
      * @param array $classes
@@ -152,22 +183,9 @@ class RoomAllocationPayloadBuilder
 
         $groupId = $fusion && $fusion->master_id ? $fusion->master_id : min($classIds);
 
-        $sameRoomCohort = null;
-
-        if ($tiptur === 'Graduação') {
-            foreach ($classes as $class) {
-                $suffix = substr($class->codtur, -2);
-
-                if (in_array($suffix, $validSuffixes, true)) {
-                    foreach ($class->courseinformations as $ci) {
-                        if ($ci->tipobg === 'O' && in_array($ci->numsemidl, ['1', '2'], true)) {
-                            $sameRoomCohort = "cohort_{$suffix}_sem_{$ci->numsemidl}";
-                            break 2;
-                        }
-                    }
-                }
-            }
-        }
+        $cohortData = $this->resolveFreshmenCohort($classes, $validSuffixes);
+        $isFreshmen = $cohortData !== null;
+        $sameRoomCohort = $isFreshmen ? "cohort_{$cohortData['suffix']}_sem_{$cohortData['semester']}" : null;
 
         return [
             'id' => $groupId,
@@ -182,6 +200,7 @@ class RoomAllocationPayloadBuilder
             'timeslot_labels' => $timeslotLabels,
             'preassigned_room_id' => null,
             'same_room_cohort' => $sameRoomCohort,
+            'is_freshmen' => $isFreshmen,
         ];
     }
 

--- a/config/alocacao.php
+++ b/config/alocacao.php
@@ -33,6 +33,9 @@ return [
     'room_allocation' => [
         'strict_capacity' => (bool) env('ROOM_ALLOCATION_STRICT_CAPACITY', true),
         'block_b_restriction_for_pos' => (bool) env('ROOM_ALLOCATION_BLOCK_B_POS', true),
+        'block_a_restriction_for_freshmen' => (bool) env('ROOM_ALLOCATION_BLOCK_A_FRESHMEN', true),
+        'undergrad_in_block_a_penalty' => (float) env('ROOM_ALLOCATION_UNDERGRAD_BLOCK_A_PENALTY', 500.0),
+        'pos_in_block_b_penalty' => (float) env('ROOM_ALLOCATION_POS_BLOCK_B_PENALTY', 500.0),
         'wasted_seats_weight' => (float) env('ROOM_ALLOCATION_WASTED_SEATS_WEIGHT', 1.0),
         'unassigned_penalty' => (float) env('ROOM_ALLOCATION_UNASSIGNED_PENALTY', 1000.0),
         'priority_weight' => (float) env('ROOM_ALLOCATION_PRIORITY_WEIGHT', 0.0),

--- a/tests/Unit/RoomAllocationPayloadBuilderTest.php
+++ b/tests/Unit/RoomAllocationPayloadBuilderTest.php
@@ -49,6 +49,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertNull($group['preassigned_room_id']);
         $this->assertArrayHasKey('same_room_cohort', $group);
         $this->assertNull($group['same_room_cohort']);
+        $this->assertArrayHasKey('is_freshmen', $group);
+        $this->assertFalse($group['is_freshmen']);
     }
 
     /** @test */
@@ -93,6 +95,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertCount(2, $group['timeslot_ids']);
         $this->assertArrayHasKey('same_room_cohort', $group);
         $this->assertNull($group['same_room_cohort']);
+        $this->assertArrayHasKey('is_freshmen', $group);
+        $this->assertFalse($group['is_freshmen']);
     }
 
     /** @test */
@@ -121,6 +125,8 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertEquals(40, $group['demand']);
         $this->assertArrayHasKey('same_room_cohort', $group);
         $this->assertNull($group['same_room_cohort']);
+        $this->assertArrayHasKey('is_freshmen', $group);
+        $this->assertFalse($group['is_freshmen']);
     }
 
     /** @test */
@@ -253,12 +259,18 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertArrayHasKey('config', $payload);
         $this->assertArrayHasKey('strict_capacity', $payload['config']);
         $this->assertArrayHasKey('block_b_restriction_for_pos', $payload['config']);
+        $this->assertArrayHasKey('block_a_restriction_for_freshmen', $payload['config']);
+        $this->assertArrayHasKey('undergrad_in_block_a_penalty', $payload['config']);
+        $this->assertArrayHasKey('pos_in_block_b_penalty', $payload['config']);
         $this->assertArrayHasKey('wasted_seats_weight', $payload['config']);
         $this->assertArrayHasKey('unassigned_penalty', $payload['config']);
         $this->assertArrayHasKey('priority_weight', $payload['config']);
 
-        $this->assertFalse($payload['config']['strict_capacity']);
+        $this->assertTrue($payload['config']['strict_capacity']);
         $this->assertTrue($payload['config']['block_b_restriction_for_pos']);
+        $this->assertTrue($payload['config']['block_a_restriction_for_freshmen']);
+        $this->assertEquals(500.0, $payload['config']['undergrad_in_block_a_penalty']);
+        $this->assertEquals(500.0, $payload['config']['pos_in_block_b_penalty']);
         $this->assertEquals(1.0, $payload['config']['wasted_seats_weight']);
         $this->assertEquals(1000.0, $payload['config']['unassigned_penalty']);
         $this->assertEquals(0.0, $payload['config']['priority_weight']);
@@ -649,5 +661,180 @@ class RoomAllocationPayloadBuilderTest extends TestCase
 
         $group = $payload['groups'][0];
         $this->assertEquals('cohort_45_sem_1', $group['same_room_cohort']);
+        $this->assertTrue($group['is_freshmen']);
+    }
+
+    /** @test */
+    public function it_marks_freshmen_single_class_as_is_freshmen_true()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $course = \App\Models\Course::factory()->create([
+            'sufixo_codtur' => '45',
+        ]);
+
+        $courseInfo = \App\Models\CourseInformation::factory()->create([
+            'tipobg' => 'O',
+            'numsemidl' => '1',
+        ]);
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'codtur' => '202445',
+            'tiptur' => 'Graduação',
+            'externa' => false,
+            'fusion_id' => null,
+        ]);
+
+        $class->courseinformations()->attach($courseInfo);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertTrue($group['is_freshmen']);
+    }
+
+    /** @test */
+    public function it_marks_pos_grad_class_as_is_freshmen_false()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'tiptur' => 'Pós Graduação',
+            'externa' => false,
+            'fusion_id' => null,
+        ]);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertFalse($group['is_freshmen']);
+    }
+
+    /** @test */
+    public function it_marks_non_mandatory_class_as_is_freshmen_false()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $course = \App\Models\Course::factory()->create([
+            'sufixo_codtur' => '45',
+        ]);
+
+        $courseInfo = \App\Models\CourseInformation::factory()->create([
+            'tipobg' => 'C',
+            'numsemidl' => '1',
+        ]);
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'codtur' => '202445',
+            'tiptur' => 'Graduação',
+            'externa' => false,
+            'fusion_id' => null,
+        ]);
+
+        $class->courseinformations()->attach($courseInfo);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertFalse($group['is_freshmen']);
+    }
+
+    /** @test */
+    public function it_marks_advanced_semester_class_as_is_freshmen_false()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $course = \App\Models\Course::factory()->create([
+            'sufixo_codtur' => '45',
+        ]);
+
+        $courseInfo = \App\Models\CourseInformation::factory()->create([
+            'tipobg' => 'O',
+            'numsemidl' => '3',
+        ]);
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'codtur' => '202445',
+            'tiptur' => 'Graduação',
+            'externa' => false,
+            'fusion_id' => null,
+        ]);
+
+        $class->courseinformations()->attach($courseInfo);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertFalse($group['is_freshmen']);
+    }
+
+    /** @test */
+    public function it_marks_fusion_as_freshmen_when_any_class_qualifies()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $course = \App\Models\Course::factory()->create([
+            'sufixo_codtur' => '45',
+        ]);
+
+        $courseInfo = \App\Models\CourseInformation::factory()->create([
+            'tipobg' => 'O',
+            'numsemidl' => '2',
+        ]);
+
+        $fusion = Fusion::factory()->create();
+
+        $classA = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'codtur' => '202445',
+            'tiptur' => 'Graduação',
+            'externa' => false,
+            'fusion_id' => $fusion->id,
+        ]);
+        $classA->courseinformations()->attach($courseInfo);
+
+        $classB = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'codtur' => '202446',
+            'tiptur' => 'Graduação',
+            'externa' => false,
+            'fusion_id' => $fusion->id,
+        ]);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $classA->classschedules()->attach($schedule);
+        $classB->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertTrue($group['is_freshmen']);
+        $this->assertEquals('cohort_45_sem_2', $group['same_room_cohort']);
     }
 }


### PR DESCRIPTION
## Summary

Atualiza o payload JSON enviado ao microserviço Python de alocação de salas (OR-Tools) para suportar novas restrições direcionais de blocos, conforme descrito na issue #49.

### Alterações principais

1. **Novas configurações no bloco `config`** (`config/alocacao.php`):
   - `block_a_restriction_for_freshmen` (bool, default: `true`) — Hard Constraint
   - `undergrad_in_block_a_penalty` (float, default: `500.0`) — Soft Constraint
   - `pos_in_block_b_penalty` (float, default: `500.0`) — Soft Constraint

2. **Identificação de calouros (`groups[].is_freshmen`)**:
   - Uma turma/grupo é marcado como `is_freshmen = true` quando:
     - `tiptur` é `"Graduação"`
     - Possui `courseinformations` obrigatórias (`tipobg == 'O'`)
     - Semestre ideal (`numsemidl`) em `['1', '2']`
     - Sufixo de `codtur` pertence a um curso do IME (via `Course::all()`)
   - A lógica de identificação foi extraída para o método privado `resolveFreshmenCohort`, eliminando a duplicação com o cálculo de `same_room_cohort`.

3. **Variáveis de ambiente** (`.env.example`):
   - Documentadas as 3 novas variáveis correspondentes.

4. **Testes unitários** (`RoomAllocationPayloadBuilderTest`):
   - 5 novos testes cobrindo: calouro verdadeiro, pós-graduação, optativa, semestre avançado e fusão mista.
   - Atualizado o teste de configurações padrão para incluir as novas chaves.
   - Corrigido assert pré-existente de `strict_capacity`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-flight Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Changes are covered by unit tests
- [x] All new and existing tests pass locally
- [x] Related issue is referenced (`Closes #49`)
