### PR TITLE
feat: preservar alocações manuais durante distribuição automatizada

### DIFF
--- a/app/Http/Controllers/AllocationResultWebhookController.php
+++ b/app/Http/Controllers/AllocationResultWebhookController.php
@@ -75,19 +75,33 @@ class AllocationResultWebhookController extends Controller
             return response()->json(['message' => 'Error recorded'], 200);
         }
 
+        $manualCount = 0;
+        $autoCount = 0;
+
         try {
-            DB::transaction(function () use ($assignments, $unassignedGroups) {
+            DB::transaction(function () use ($assignments, $unassignedGroups, &$manualCount, &$autoCount) {
                 // Apply allocated room_ids
                 foreach ($assignments as $assignment) {
                     $groupId = $assignment['group_id'];
                     $roomId = $assignment['room_id'];
 
                     SchoolClass::where('id', $groupId)->update(['room_id' => $roomId]);
+                    $autoCount++;
                 }
 
-                // Clear unassigned groups
+                // Clear unassigned groups, but preserve manual allocations
                 if (! empty($unassignedGroups)) {
-                    SchoolClass::whereIn('id', $unassignedGroups)->update(['room_id' => null]);
+                    $alreadyAllocated = SchoolClass::whereIn('id', $unassignedGroups)
+                        ->whereNotNull('room_id')
+                        ->pluck('id')
+                        ->toArray();
+
+                    $toClear = array_diff($unassignedGroups, $alreadyAllocated);
+                    if (! empty($toClear)) {
+                        SchoolClass::whereIn('id', $toClear)->update(['room_id' => null]);
+                    }
+
+                    $manualCount = count($alreadyAllocated);
                 }
             });
         } catch (\Exception $e) {
@@ -119,15 +133,17 @@ class AllocationResultWebhookController extends Controller
         $activeJob['progress'] = 100;
         $activeJob['message'] = 'Distribuição concluída';
         $activeJob['finished_at'] = now()->toIso8601String();
-        $activeJob['assignments_count'] = count($assignments);
-        $activeJob['unassigned_count'] = count($unassignedGroups);
+        $activeJob['assignments_count'] = $autoCount;
+        $activeJob['unassigned_count'] = count($unassignedGroups) - $manualCount;
+        $activeJob['manual_count'] = $manualCount;
         Cache::put($cacheKey, $activeJob, now()->addHours(4));
 
         Log::info('AllocationResultWebhook: results applied successfully', [
             'job_id' => $jobId,
             'school_term_id' => $schoolTermId,
-            'assignments_count' => count($assignments),
-            'unassigned_count' => count($unassignedGroups),
+            'assignments_count' => $autoCount,
+            'unassigned_count' => count($unassignedGroups) - $manualCount,
+            'manual_count' => $manualCount,
         ]);
 
         return response()->json(['message' => 'Results applied'], 200);

--- a/app/Http/Controllers/AllocationResultWebhookController.php
+++ b/app/Http/Controllers/AllocationResultWebhookController.php
@@ -23,8 +23,8 @@ class AllocationResultWebhookController extends Controller
             'job_id' => 'required|string',
             'status' => 'required|string|in:optimal,feasible,stopped,infeasible,error',
             'allocations' => 'nullable|array',
-            'assignments.*.group_id' => 'required_with:assignments|integer',
-            'assignments.*.room_id' => 'required_with:assignments|integer',
+            'allocations.*.group_id' => 'required_with:allocations|integer',
+            'allocations.*.room_id' => 'required_with:allocations|integer',
             'unassigned_groups' => 'nullable|array',
             'unassigned_groups.*' => 'integer',
             'suggestions' => 'nullable|array',
@@ -33,7 +33,7 @@ class AllocationResultWebhookController extends Controller
 
         $jobId = $validated['job_id'];
         $status = $validated['status'];
-        $assignments = $validated['allocations'] ??[];
+        $assignments = $validated['allocations'] ?? [];
         $unassignedGroups = $validated['unassigned_groups'] ?? [];
         $suggestions = $validated['suggestions'] ?? [];
 

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -75,11 +75,15 @@ class MonitorController extends Controller
             'status' => $cached['status'] ?? 'unknown',
             'message' => $cached['message'] ?? '',
             'failed' => $isFailed,
+            'assignments_count' => $cached['assignments_count'] ?? 0,
+            'unassigned_count' => $cached['unassigned_count'] ?? 0,
+            'manual_count' => $cached['manual_count'] ?? 0,
             'data' => json_encode([
                 'status' => $cached['status'],
                 'message' => $cached['message'],
                 'assignments_count' => $cached['assignments_count'] ?? 0,
                 'unassigned_count' => $cached['unassigned_count'] ?? 0,
+                'manual_count' => $cached['manual_count'] ?? 0,
             ]),
         ]);
     }

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -368,12 +368,27 @@ class RoomController extends Controller
             $assignments = $data['assignments'] ?? [];
             $unassignedGroups = $data['unassigned_groups'] ?? [];
 
-            DB::transaction(function () use ($assignments, $unassignedGroups) {
+            $manualCount = 0;
+            $autoCount = 0;
+
+            DB::transaction(function () use ($assignments, $unassignedGroups, &$manualCount, &$autoCount) {
                 foreach ($assignments as $assignment) {
                     SchoolClass::where('id', $assignment['group_id'])->update(['room_id' => $assignment['room_id']]);
+                    $autoCount++;
                 }
+
                 if (! empty($unassignedGroups)) {
-                    SchoolClass::whereIn('id', $unassignedGroups)->update(['room_id' => null]);
+                    $alreadyAllocated = SchoolClass::whereIn('id', $unassignedGroups)
+                        ->whereNotNull('room_id')
+                        ->pluck('id')
+                        ->toArray();
+
+                    $toClear = array_diff($unassignedGroups, $alreadyAllocated);
+                    if (! empty($toClear)) {
+                        SchoolClass::whereIn('id', $toClear)->update(['room_id' => null]);
+                    }
+
+                    $manualCount = count($alreadyAllocated);
                 }
             });
 
@@ -388,8 +403,9 @@ class RoomController extends Controller
                 'progress' => 100,
                 'message' => 'Distribuição concluída (via resgate)',
                 'finished_at' => now()->toIso8601String(),
-                'assignments_count' => count($assignments),
-                'unassigned_count' => count($unassignedGroups),
+                'assignments_count' => $autoCount,
+                'unassigned_count' => count($unassignedGroups) - $manualCount,
+                'manual_count' => $manualCount,
             ], now()->addHours(4));
 
             Session::put("alert-info", "Resultado resgatado e aplicado com sucesso.");

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -365,7 +365,7 @@ class RoomController extends Controller
             }
 
             $data = $response->json();
-            $assignments = $data['assignments'] ?? [];
+            $assignments = $data['allocations'] ?? [];
             $unassignedGroups = $data['unassigned_groups'] ?? [];
 
             $manualCount = 0;

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -202,7 +202,18 @@ class RoomController extends Controller
 
         $validated = $request->validated();
 
-        $room->schoolclasses()->save(SchoolClass::find($validated["school_class_id"]));
+        $schoolClass = SchoolClass::find($validated["school_class_id"]);
+        $room->schoolclasses()->save($schoolClass);
+
+        // If the class is part of a fusion, ensure the master also gets the room_id
+        if ($schoolClass->fusion_id) {
+            $fusion = $schoolClass->fusion;
+            if ($fusion && $fusion->master_id && $fusion->master_id != $schoolClass->id) {
+                $master = $fusion->master;
+                $master->room_id = $room->id;
+                $master->save();
+            }
+        }
 
         return back();
     }

--- a/app/Services/RoomAllocationPayloadBuilder.php
+++ b/app/Services/RoomAllocationPayloadBuilder.php
@@ -29,7 +29,7 @@ class RoomAllocationPayloadBuilder
     public function build(SchoolTerm $schoolTerm, array $roomIds, array $overrides = []): array
     {
         $allClasses = SchoolClass::whereBelongsTo($schoolTerm)
-            ->with(['classschedules', 'fusion', 'courseinformations', 'room'])
+            ->with(['classschedules', 'fusion.master', 'fusion.master.room', 'courseinformations', 'room'])
             ->orderBy('id')
             ->get();
 

--- a/app/Services/RoomAllocationPayloadBuilder.php
+++ b/app/Services/RoomAllocationPayloadBuilder.php
@@ -187,7 +187,21 @@ class RoomAllocationPayloadBuilder
         $isFreshmen = $cohortData !== null;
         $sameRoomCohort = $isFreshmen ? "cohort_{$cohortData['suffix']}_sem_{$cohortData['semester']}" : null;
 
-        $rawRoomId = $fusion && $fusion->master ? $fusion->master->room_id : $representative->room_id;
+        if ($fusion) {
+            $rawRoomId = $fusion->master && $fusion->master->room_id
+                ? $fusion->master->room_id
+                : null;
+            if ($rawRoomId === null) {
+                foreach ($classes as $c) {
+                    if ($c->room_id !== null) {
+                        $rawRoomId = $c->room_id;
+                        break;
+                    }
+                }
+            }
+        } else {
+            $rawRoomId = $representative->room_id;
+        }
         $preassignedRoomId = ($rawRoomId !== null && in_array($rawRoomId, $availableRoomIds, true))
             ? $rawRoomId
             : null;

--- a/app/Services/RoomAllocationPayloadBuilder.php
+++ b/app/Services/RoomAllocationPayloadBuilder.php
@@ -29,7 +29,7 @@ class RoomAllocationPayloadBuilder
     public function build(SchoolTerm $schoolTerm, array $roomIds, array $overrides = []): array
     {
         $allClasses = SchoolClass::whereBelongsTo($schoolTerm)
-            ->with(['classschedules', 'fusion', 'courseinformations'])
+            ->with(['classschedules', 'fusion', 'courseinformations', 'room'])
             ->orderBy('id')
             ->get();
 
@@ -37,7 +37,7 @@ class RoomAllocationPayloadBuilder
 
         $validSuffixes = Course::all()->pluck('sufixo_codtur')->toArray();
 
-        $groups = $this->resolveGroups($canonical, $validSuffixes);
+        $groups = $this->resolveGroups($canonical, $validSuffixes, $roomIds);
 
         $timeslots = $this->buildTimeslotCatalog($groups);
 
@@ -100,7 +100,7 @@ class RoomAllocationPayloadBuilder
      * @param Collection $schoolClasses
      * @return array
      */
-    private function resolveGroups(Collection $schoolClasses, array $validSuffixes): array
+    private function resolveGroups(Collection $schoolClasses, array $validSuffixes, array $availableRoomIds): array
     {
         $solo = $schoolClasses->whereNull('fusion_id');
         $fused = $schoolClasses->whereNotNull('fusion_id')->groupBy('fusion_id');
@@ -108,12 +108,12 @@ class RoomAllocationPayloadBuilder
         $groups = [];
 
         foreach ($solo as $class) {
-            $groups[] = $this->buildSingleGroup([$class], null, $validSuffixes);
+            $groups[] = $this->buildSingleGroup([$class], null, $validSuffixes, $availableRoomIds);
         }
 
         foreach ($fused as $fusionId => $classes) {
             $fusion = $classes->first()->fusion;
-            $groups[] = $this->buildSingleGroup($classes->all(), $fusion, $validSuffixes);
+            $groups[] = $this->buildSingleGroup($classes->all(), $fusion, $validSuffixes, $availableRoomIds);
         }
 
         return $groups;
@@ -157,7 +157,7 @@ class RoomAllocationPayloadBuilder
      * @param Fusion|null $fusion
      * @return array
      */
-    private function buildSingleGroup(array $classes, ?Fusion $fusion, array $validSuffixes): array
+    private function buildSingleGroup(array $classes, ?Fusion $fusion, array $validSuffixes, array $availableRoomIds): array
     {
         usort($classes, fn ($a, $b) => $a->id <=> $b->id);
 
@@ -187,6 +187,11 @@ class RoomAllocationPayloadBuilder
         $isFreshmen = $cohortData !== null;
         $sameRoomCohort = $isFreshmen ? "cohort_{$cohortData['suffix']}_sem_{$cohortData['semester']}" : null;
 
+        $rawRoomId = $fusion && $fusion->master ? $fusion->master->room_id : $representative->room_id;
+        $preassignedRoomId = ($rawRoomId !== null && in_array($rawRoomId, $availableRoomIds, true))
+            ? $rawRoomId
+            : null;
+
         return [
             'id' => $groupId,
             'type' => $fusion ? 'fusion' : 'single',
@@ -198,7 +203,7 @@ class RoomAllocationPayloadBuilder
             'demand' => $demand,
             'has_null_enrollment' => $hasNull,
             'timeslot_labels' => $timeslotLabels,
-            'preassigned_room_id' => null,
+            'preassigned_room_id' => $preassignedRoomId,
             'same_room_cohort' => $sameRoomCohort,
             'is_freshmen' => $isFreshmen,
         ];

--- a/resources/views/rooms/index.blade.php
+++ b/resources/views/rooms/index.blade.php
@@ -371,7 +371,20 @@ $( function() {
                             document.getElementById("btn-fallback-distribution").style.display = 'none';
                             $( "#progressbar" ).remove();
                             $('#flash-message').empty();
-                            $('#flash-message').append("<p id='success-message' class='alert alert-success'>As turmas foram distribuídas nas salas com sucesso.</p>");
+
+                            var autoCount = json['assignments_count'] || 0;
+                            var manualCount = json['manual_count'] || 0;
+                            var unassignedCount = json['unassigned_count'] || 0;
+                            var successMsg = 'Distribuição concluída. ' +
+                                autoCount + ' turma(s) alocada(s) automaticamente';
+                            if (manualCount > 0) {
+                                successMsg += ', ' + manualCount + ' turma(s) manual(is) preservada(s)';
+                            }
+                            if (unassignedCount > 0) {
+                                successMsg += ', ' + unassignedCount + ' turma(s) não alocada(s)';
+                            }
+                            successMsg += '.';
+                            $('#flash-message').append("<p id='success-message' class='alert alert-success'>" + successMsg + "</p>");
 
                             setTimeout(function() { window.location.reload(); }, 2500);
                         }

--- a/tests/Unit/RoomAllocationPayloadBuilderTest.php
+++ b/tests/Unit/RoomAllocationPayloadBuilderTest.php
@@ -837,4 +837,81 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertTrue($group['is_freshmen']);
         $this->assertEquals('cohort_45_sem_2', $group['same_room_cohort']);
     }
+
+    /** @test */
+    public function it_sets_preassigned_room_id_when_class_has_room_in_available_list()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $room->id,
+            'externa' => false,
+            'fusion_id' => null,
+        ]);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertEquals($room->id, $group['preassigned_room_id']);
+    }
+
+    /** @test */
+    public function it_does_not_set_preassigned_room_id_when_class_room_is_not_in_available_list()
+    {
+        $term = SchoolTerm::factory()->create();
+        $roomA = Room::factory()->create();
+        $roomB = Room::factory()->create();
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $roomB->id,
+            'externa' => false,
+            'fusion_id' => null,
+        ]);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$roomA->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertNull($group['preassigned_room_id']);
+    }
+
+    /** @test */
+    public function it_sets_preassigned_room_id_for_fusion_master_when_available()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $fusion = Fusion::factory()->create();
+        $master = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $room->id,
+            'fusion_id' => $fusion->id,
+        ]);
+        $slave = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'fusion_id' => $fusion->id,
+        ]);
+        $fusion->master()->associate($master);
+        $fusion->save();
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $master->classschedules()->attach($schedule);
+        $slave->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertEquals($room->id, $group['preassigned_room_id']);
+    }
 }


### PR DESCRIPTION
## Descrição

Implementa a preservação de alocações manuais durante a distribuição automatizada de salas (Issue #53).

### Problema

Ao rodar a distribuição automática via solver, turmas que já haviam sido alocadas manualmente pelos usuários perdiam sua sala. O sistema enviava todas as turmas ao solver sem informar quais já estavam alocadas, e o webhook de resultado limpava o `room_id` de todas as turmas que o solver não conseguiu alocar.

### Mudanças

- **Payload Builder** (`RoomAllocationPayloadBuilder.php`):
  - Envia `preassigned_room_id` ao solver para turmas que já possuem sala
  - Para fusões, verifica todas as turmas do grupo (não só a master) para identificar alocações manuais
  - Eager loading de `fusion.master.room` para garantir consistência

- **Webhook** (`AllocationResultWebhookController.php`):
  - Corrige leitura do campo `allocations` (estava lendo `assignments`)
  - Preserva `room_id` de turmas manualmente alocadas quando estão em `unassigned_groups`
  - Adiciona tracking de `manual_count` vs `auto_count`

- **Fallback** (`RoomController::fallbackDistribution`):
  - Mesma correção de leitura do campo `allocations`
  - Mesma lógica de preservação de alocações manuais

- **Alocação Manual** (`RoomController::allocate`):
  - Quando uma turma slave de uma fusão é alocada manualmente, sincroniza o `room_id` para a master

- **UI** (`rooms/index.blade.php` e `MonitorController`):
  - Mensagem de sucesso mostra breakdown: automáticas / manuais preservadas / não alocadas

- **Testes**:
  - Adicionados testes para `preassigned_room_id` em turmas simples e fusões

### Como testar

1. Esvaziar as salas
2. Alocar manualmente uma turma (ou fusão) em uma sala
3. Rodar a distribuição automática
4. Verificar que a turma manual permanece na sala
5. Verificar que o solver não aloca outra turma no mesmo horário/sala

Closes #53