### PR TITLE
feat(views): adiciona coluna de quantidade de inscritos nas tabelas de turmas

### DIFF
--- a/resources/views/fusions/index.blade.php
+++ b/resources/views/fusions/index.blade.php
@@ -26,6 +26,7 @@
                         <th>Código da Turma</th>
                         <th>Nome da Disciplina</th>
                         <th>Tipo da Turma</th>
+                        <th>Inscritos</th>
                         <th>Desmembrar<br></th>
                     </tr>
 
@@ -66,6 +67,7 @@
                                 <td style="vertical-align: middle;">{{ $fusion->schoolclasses[$x]->codtur }}</td>
                                 <td style="vertical-align: middle;">{{ $fusion->schoolclasses[$x]->nomdis }}</td>
                                 <td style="vertical-align: middle;">{{ $fusion->schoolclasses[$x]->tiptur }}</td>
+                                <td style="vertical-align: middle;">{{ $fusion->schoolclasses[$x]->estmtr ?? '-' }}</td>
                                 <td>
                                     <form method="get"  action="{{ route('fusions.disjoint', $fusion->schoolclasses[$x]) }}" style="display: inline;">
                                         @csrf

--- a/resources/views/rooms/show.blade.php
+++ b/resources/views/rooms/show.blade.php
@@ -200,6 +200,7 @@
                         <th>Código da Turma</th>
                         <th>Nome da Disciplina</th>
                         <th>Tipo da Turma</th>
+                        <th>Inscritos</th>
                         <th>Horários</th>
                         <th>Professor(es)</th>
                     </tr>
@@ -220,6 +221,7 @@
                                 @endif
                             </td>
                             <td>{{ $turma->tiptur }}</td>
+                            <td>{{ $turma->estmtr ?? '-' }}</td>
                             <td style="{{ $room->isCompatible($turma, $ignore_block=true, $ignore_estmtr=true) ? 'white-space: nowrap;color:green;' : 'white-space: nowrap;color:red' }}">
                                 @foreach($turma->classschedules as $horario)
                                     {{ $horario->diasmnocp . ' ' . $horario->horent . ' ' . $horario->horsai }} <br/>
@@ -246,6 +248,7 @@
                         <th>Código da Turma</th>
                         <th>Nome da Disciplina</th>
                         <th>Tipo da Turma</th>
+                        <th>Inscritos</th>
                         <th>Horários</th>
                         <th>Professor(es)</th>
                     </tr>
@@ -289,6 +292,7 @@
                                     @endif
                                 </td>
                                 <td>{{ $fusion->schoolclasses[$x]->tiptur }}</td>
+                                <td>{{ $fusion->schoolclasses[$x]->estmtr ?? '-' }}</td>
                                 @if($x == 0)
                                     <td rowspan="{{count($fusion->schoolclasses)}}" 
                                     style="{{ $room->isCompatible($fusion->master, $ignore_block=true, $ignore_estmtr=true) ? 'white-space: nowrap;vertical-align: middle;color:green;' : 'white-space: nowrap;vertical-align: middle;color:red' }}">

--- a/resources/views/rooms/showFreeTime.blade.php
+++ b/resources/views/rooms/showFreeTime.blade.php
@@ -64,6 +64,7 @@
                                 <th>Código da Turma</th>
                                 <th>Nome da Disciplina</th>
                                 <th>Tipo da Turma</th>
+                                <th>Inscritos</th>
                                 <th>Horários</th>
                                 <th>Professor(es)</th>
                                 <th>Salas<br>Compatíveis</th>
@@ -85,6 +86,7 @@
                                         @endif
                                     </td>
                                     <td>{{ $turma->tiptur }}</td>
+                                    <td>{{ $turma->estmtr ?? '-' }}</td>
                                     <td style="white-space: nowrap;">
                                         @foreach($turma->classschedules as $horario)
                                             {{ $horario->diasmnocp . ' ' . $horario->horent . ' ' . $horario->horsai }} <br/>
@@ -131,6 +133,7 @@
                                 <th>Código da Turma</th>
                                 <th>Nome da Disciplina</th>
                                 <th>Tipo da Turma</th>
+                                <th>Inscritos</th>
                                 <th>Horários</th>
                                 <th>Professor(es)</th>
                                 <th>Salas<br>Compatíveis</th>
@@ -170,6 +173,7 @@
                                             @endif
                                         </td>
                                         <td>{{ $fusion->schoolclasses[$x]->tiptur }}</td>
+                                        <td>{{ $fusion->schoolclasses[$x]->estmtr ?? '-' }}</td>
                                         @if($x == 0)
                                             <td rowspan="{{count($fusion->schoolclasses)}}" 
                                             style="white-space: nowrap;vertical-align: middle;">

--- a/resources/views/schoolclasses/externals.blade.php
+++ b/resources/views/schoolclasses/externals.blade.php
@@ -47,6 +47,7 @@
                         <th>Código da Turma</th>
                         <th>Nome da Disciplina</th>
                         <th>Tipo da Turma</th>
+                        <th>Inscritos</th>
                         <th>Horários</th>
                         <th>Professor(es)</th>
                         <th>Início</th>
@@ -72,6 +73,7 @@
                                 @endif
                             </td>
                             <td>{{ $turma->tiptur }}</td>
+                            <td>{{ $turma->estmtr ?? '-' }}</td>
                             <td style="white-space: nowrap;">
                                 @foreach($turma->classschedules as $horario)
                                     {{ $horario->diasmnocp . ' ' . $horario->horent . ' ' . $horario->horsai }} <br/>

--- a/resources/views/schoolclasses/index.blade.php
+++ b/resources/views/schoolclasses/index.blade.php
@@ -54,6 +54,7 @@
                         <th>Código da Turma</th>
                         <th>Nome da Disciplina</th>
                         <th>Tipo da Turma</th>
+                        <th>Inscritos</th>
                         <th>Horários</th>
                         <th>Professor(es)</th>
                         <th>Início</th>
@@ -78,6 +79,7 @@
                                 @endif
                             </td>
                             <td>{{ $turma->tiptur }}</td>
+                            <td>{{ $turma->estmtr ?? '-' }}</td>
                             <td style="white-space: nowrap;">
                                 @foreach($turma->classschedules as $horario)
                                     {{ $horario->diasmnocp . ' ' . $horario->horent . ' ' . $horario->horsai }} <br/>

--- a/resources/views/specialoffers/index.blade.php
+++ b/resources/views/specialoffers/index.blade.php
@@ -31,6 +31,7 @@
                         <th>Código da Disciplina</th>
                         <th>Nome da Disciplina</th>
                         <th>Código da Turma</th>
+                        <th>Inscritos</th>
                         <th>Horários</th>
                         <th>Professor(es)</th>
                     </tr>
@@ -61,10 +62,12 @@
                                     <td>Sem oferecimento</td>
                                     <td>Sem oferecimento</td>
                                     <td>Sem oferecimento</td>
+                                    <td>Sem oferecimento</td>
                                     </tr>
                                 @else
                                     @foreach($disciplina['turmas'] as $turma)
                                         <td>{{ $turma->codtur }}</td>
+                                        <td>{{ $turma->estmtr ?? '-' }}</td>
                                         <td style="white-space: nowrap;">
                                             @foreach($turma->classschedules as $horario)
                                                 {{ $horario->diasmnocp . ' ' . $horario->horent . ' ' . $horario->horsai }} <br/>


### PR DESCRIPTION
## Descrição

Inclui a coluna **"Inscritos"** em todas as visualizações de tabela que listam turmas e disciplinas, conforme solicitado na issue #54.

A coluna exibe o valor do campo `estmtr` (número estimado de matriculados) do modelo `SchoolClass`. Quando o valor é nulo, exibe `-`.

## Locais Alterados

- **Turmas Internas** (`schoolclasses/index.blade.php`)
- **Turmas Externas** (`schoolclasses/externals.blade.php`)
- **Dobradinhas** (`fusions/index.blade.php`)
- **Visualização por Sala** (`rooms/show.blade.php`)
- **Horários Livres por Sala** (`rooms/showFreeTime.blade.php`)
- **Oferecimentos Especiais** (`specialoffers/index.blade.php`)

## Tipo de Mudança

- [x] Nova funcionalidade (feat)

## Checklist

- [x] Coluna "Inscritos" adicionada em todas as tabelas de gerenciamento de turmas
- [x] Valor corresponde ao dado real (`estmtr`) presente no banco de dados
- [x] Tratamento para valores nulos (`-`)

Closes #54
