### PR TITLE
feat(solver): apply historical demand estimation for freshmen classes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -251,6 +251,28 @@ ALOCACAO_SOLVER_TIMEOUT=60
 # Verificar SSL em ambiente de produção
 ALOCACAO_SOLVER_VERIFY_SSL=true
 
+# ESTIMATIVA HISTÓRICA DE DEMANDA PARA TURMAS DE 1º SEMESTRE (Issue 55)
+# Threshold percentual para ativar a estimativa histórica no payload do solver.
+# Quando (media_historica - estmtr) / media_historica > threshold, a demanda
+# enviada ao solver usa a estimativa histórica em vez do estmtr atual.
+HISTORICAL_THRESHOLD_PERCENT=7.0
+
+# Número de anos anteriores a consultar no cálculo da média histórica
+HISTORICAL_LOOKBACK_YEARS=5
+
+# Número mínimo de anos históricos com dados para considerar a estimativa confiável
+HISTORICAL_MIN_YEARS=2
+
+# Método de estimativa: 'average_plus_stddev' usa media + (multiplicador * DP).
+# Outros valores desativam a estimativa ajustada (usa estmtr puro).
+HISTORICAL_ESTIMATION_METHOD=average_plus_stddev
+
+# Multiplicador do desvio padrão. 3 DP é conservador e evita superlotação.
+HISTORICAL_STDDEV_MULTIPLIER=3.0
+
+# Teto máximo para a estimativa histórica. Evita demandas irreais no solver.
+HISTORICAL_CAP=100
+
 # RESTRIÇÕES DIRECIONAIS DE BLOCOS (Issue 49)
 # Hard Constraint: protege calouros do IME no Bloco A
 ROOM_ALLOCATION_BLOCK_A_FRESHMEN=true

--- a/app/Services/HistoricalEnrollmentService.php
+++ b/app/Services/HistoricalEnrollmentService.php
@@ -34,6 +34,21 @@ class HistoricalEnrollmentService
     private int $minHistoricalYears = 2;
 
     /**
+     * Método de estimativa de demanda para o payload do solver.
+     */
+    private string $estimationMethod = 'average_plus_stddev';
+
+    /**
+     * Multiplicador do desvio padrão quando estimationMethod = 'average_plus_stddev'.
+     */
+    private float $stddevMultiplier = 3.0;
+
+    /**
+     * Teto máximo para a estimativa histórica de demanda.
+     */
+    private int $cap = 100;
+
+    /**
      * Palavras-chave em obstur que indicam turmas especiais e devem ser excluídas.
      */
     private array $exclusionObsturKeywords = [
@@ -50,6 +65,9 @@ class HistoricalEnrollmentService
     {
         $this->thresholdPercent = (float) config('alocacao.historical_threshold_percent', 7.0);
         $this->minHistoricalYears = (int) config('alocacao.historical_min_years', 2);
+        $this->estimationMethod = (string) config('alocacao.historical_estimation_method', 'average_plus_stddev');
+        $this->stddevMultiplier = (float) config('alocacao.historical_stddev_multiplier', 3.0);
+        $this->cap = (int) config('alocacao.historical_cap', 100);
     }
 
     /**
@@ -105,6 +123,149 @@ class HistoricalEnrollmentService
             'average' => $result['average'],
             'samples' => $result['samples'],
             'years' => $result['years'],
+        ]);
+
+        return $result;
+    }
+
+    /**
+     * Calcula estatísticas históricas completas (média, DP, amostras, anos) para uma turma.
+     *
+     * @param string $coddis Código da disciplina
+     * @param string $codtur Código completo da turma (AAAASXX)
+     * @param int|null $currentYear Ano atual
+     * @return array{
+     *   average: float|null,
+     *   stddev: float|null,
+     *   samples: int,
+     *   years: int[]
+     * }
+     */
+    public function calculateHistoricalStats(string $coddis, string $codtur, ?int $currentYear = null): array
+    {
+        $result = [
+            'average' => null,
+            'stddev' => null,
+            'samples' => 0,
+            'years' => [],
+        ];
+
+        if (!$currentYear) {
+            $latestTerm = SchoolTerm::getLatest();
+            $currentYear = $latestTerm ? (int) $latestTerm->year : (int) date('Y');
+        }
+
+        $codturSuffix = substr($codtur, -2);
+        $historicalData = $this->fetchHistoricalEnrollments($coddis, $codturSuffix, $currentYear);
+
+        if (empty($historicalData)) {
+            return $result;
+        }
+
+        $enrollments = array_column($historicalData, 'total_matriculados');
+        $average = array_sum($enrollments) / count($enrollments);
+
+        $variance = 0.0;
+        if (count($enrollments) >= 2) {
+            $variance = array_sum(array_map(fn ($x) => pow($x - $average, 2), $enrollments)) / count($enrollments);
+        }
+        $stddev = sqrt($variance);
+
+        $result['average'] = round($average, 2);
+        $result['stddev'] = round($stddev, 2);
+        $result['samples'] = count($historicalData);
+        $result['years'] = array_column($historicalData, 'year');
+
+        return $result;
+    }
+
+    /**
+     * Calcula a demanda ajustada para o payload do solver sem alterar o banco de dados.
+     *
+     * Aplica a estimativa histórica apenas quando:
+     * - A turma é de 1º semestre obrigatório de graduação do IME;
+     * - Não possui observações especiais em obstur;
+     * - Há dados históricos suficientes;
+     * - O estmtr atual está subdimensionado em mais do que thresholdPercent.
+     *
+     * O método de estimativa é configurável. Para 'average_plus_stddev', usa
+     * min(média + (multiplicador * DP), cap). Outros métodos desativam o ajuste.
+     *
+     * @param SchoolClass $schoolClass
+     * @return array{
+     *   demand: int|null,
+     *   applied: bool,
+     *   metadata: array<string, mixed>|null
+     * }
+     */
+    public function calculateAdjustedDemand(SchoolClass $schoolClass): array
+    {
+        $result = [
+            'demand' => $schoolClass->estmtr,
+            'applied' => false,
+            'metadata' => null,
+        ];
+
+        // Só aplica para turmas de Graduação no 1º semestre
+        if (!$this->isFirstSemesterClass($schoolClass)) {
+            return $result;
+        }
+
+        // Ignora turmas com observações especiais
+        if ($this->hasSpecialObstur($schoolClass)) {
+            return $result;
+        }
+
+        $year = (int) substr($schoolClass->codtur, 0, 4);
+        $stats = $this->calculateHistoricalStats($schoolClass->coddis, $schoolClass->codtur, $year);
+
+        // Não aplica sem dados históricos suficientes
+        if ($stats['samples'] < $this->minHistoricalYears || $stats['average'] === null || $stats['average'] <= 0) {
+            return $result;
+        }
+
+        $currentEnrollment = $schoolClass->estmtr ?? 0;
+
+        // Só corrige subdimensionamento
+        $deviationPercent = (($stats['average'] - $currentEnrollment) / $stats['average']) * 100;
+        if ($deviationPercent <= $this->thresholdPercent) {
+            return $result;
+        }
+
+        // Se método não for o esperado, mantém estmtr
+        if ($this->estimationMethod !== 'average_plus_stddev') {
+            return $result;
+        }
+
+        $stddev = $stats['stddev'] ?? 0;
+        $estimatedDemand = (int) round($stats['average'] + ($stddev * $this->stddevMultiplier));
+        $estimatedDemand = min($estimatedDemand, $this->cap);
+
+        // Não aplica se a estimativa for menor que o atual (proteção extra)
+        if ($estimatedDemand <= $currentEnrollment) {
+            return $result;
+        }
+
+        $result['demand'] = $estimatedDemand;
+        $result['applied'] = true;
+        $result['metadata'] = [
+            'method' => $this->estimationMethod,
+            'average' => $stats['average'],
+            'stddev' => $stddev,
+            'stddev_multiplier' => $this->stddevMultiplier,
+            'cap' => $this->cap,
+            'current' => $currentEnrollment,
+            'deviation_percent' => round($deviationPercent, 2),
+            'threshold' => $this->thresholdPercent,
+            'years' => $stats['years'],
+            'samples' => $stats['samples'],
+        ];
+
+        Log::info('HistoricalEnrollmentService: calculated adjusted demand for payload', [
+            'coddis' => $schoolClass->coddis,
+            'codtur' => $schoolClass->codtur,
+            'old_estmtr' => $currentEnrollment,
+            'new_demand' => $estimatedDemand,
         ]);
 
         return $result;

--- a/app/Services/RoomAllocationPayloadBuilder.php
+++ b/app/Services/RoomAllocationPayloadBuilder.php
@@ -10,6 +10,13 @@ use Illuminate\Support\Collection;
 
 class RoomAllocationPayloadBuilder
 {
+    private HistoricalEnrollmentService $historicalService;
+
+    public function __construct(?HistoricalEnrollmentService $historicalService = null)
+    {
+        $this->historicalService = $historicalService ?? app(HistoricalEnrollmentService::class);
+    }
+
     /**
      * Retorna o schema version esperado pelo solver.
      */
@@ -193,10 +200,34 @@ class RoomAllocationPayloadBuilder
             }
         }
 
-        $estmtrs = array_map(fn ($c) => $c->estmtr, $classes);
-        $hasNull = in_array(null, $estmtrs, true);
-        $validEstmtrs = array_filter($estmtrs, fn ($v) => $v !== null);
-        $demand = array_sum($validEstmtrs);
+        $adjustedDemands = [];
+        $hasNull = false;
+        $historicalAdjustmentApplied = false;
+        $historicalAdjustmentMetadata = [];
+
+        foreach ($classes as $class) {
+            if ($class->estmtr === null) {
+                $hasNull = true;
+                continue;
+            }
+
+            $adjusted = $this->historicalService->calculateAdjustedDemand($class);
+            $adjustedDemands[] = $adjusted['demand'];
+
+            if ($adjusted['applied']) {
+                $historicalAdjustmentApplied = true;
+                $metadata = $adjusted['metadata'] ?? [];
+                $historicalAdjustmentMetadata[] = array_merge([
+                    'class_id' => $class->id,
+                    'coddis' => $class->coddis,
+                    'codtur' => $class->codtur,
+                    'estmtr' => $class->estmtr,
+                    'adjusted_demand' => $adjusted['demand'],
+                ], $metadata);
+            }
+        }
+
+        $demand = array_sum($adjustedDemands);
 
         $timeslotLabels = $fusion
             ? $this->buildMergedTimeslotLabels($classes)
@@ -239,6 +270,8 @@ class RoomAllocationPayloadBuilder
             'preassigned_room_id' => $preassignedRoomId,
             'same_room_cohort' => $sameRoomCohort,
             'is_freshmen' => $isFreshmen,
+            'historical_adjustment_applied' => $historicalAdjustmentApplied,
+            'historical_adjustment_metadata' => $historicalAdjustmentMetadata ?: null,
         ];
     }
 

--- a/config/alocacao.php
+++ b/config/alocacao.php
@@ -27,6 +27,31 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Método de estimativa de demanda para turmas de 1º semestre no payload do
+    | solver. 'average_plus_stddev' usa média + (multiplicador * desvio padrão).
+    | Outros valores desativam a estimativa ajustada (usa estmtr puro).
+    |--------------------------------------------------------------------------
+    */
+    'historical_estimation_method' => env('HISTORICAL_ESTIMATION_METHOD', 'average_plus_stddev'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Multiplicador do desvio padrão quando historical_estimation_method for
+    | 'average_plus_stddev'. Valores maiores geram estimativas mais conservadoras.
+    |--------------------------------------------------------------------------
+    */
+    'historical_stddev_multiplier' => (float) env('HISTORICAL_STDDEV_MULTIPLIER', 3.0),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Teto máximo para a estimativa histórica de demanda no payload do solver.
+    | Evita que turmas muito grandes sejam enviadas para salas inadequadas.
+    |--------------------------------------------------------------------------
+    */
+    'historical_cap' => (int) env('HISTORICAL_CAP', 100),
+
+    /*
+    |--------------------------------------------------------------------------
     | Configurações do solver de alocação de salas (OR-Tools Python).
     |--------------------------------------------------------------------------
     */

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <server name="APP_ENV" value="testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
-        <!-- <server name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <server name="DB_DATABASE" value=":memory:"/> -->
+        <server name="DB_CONNECTION" value="sqlite"/>
+        <server name="DB_DATABASE" value=":memory:"/>
         <server name="MAIL_MAILER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>

--- a/tests/Feature/DistributionFlowTest.php
+++ b/tests/Feature/DistributionFlowTest.php
@@ -213,7 +213,7 @@ class DistributionFlowTest extends TestCase
             'http://solver.test/api/v1/jobs/fallback-123/result' => Http::response([
                 'job_id' => 'fallback-123',
                 'status' => 'success',
-                'assignments' => [
+                'allocations' => [
                     ['group_id' => $class->id, 'room_id' => $room->id],
                 ],
                 'unassigned_groups' => [],

--- a/tests/Unit/HistoricalEnrollmentServiceTest.php
+++ b/tests/Unit/HistoricalEnrollmentServiceTest.php
@@ -267,4 +267,138 @@ class HistoricalEnrollmentServiceTest extends TestCase
         $this->assertEquals(40, $class->estmtr);
         $this->assertNull($class->historical_avg_applied_at);
     }
+
+    /** @test */
+    public function it_calculates_adjusted_demand_using_average_plus_stddev()
+    {
+        $service = Mockery::mock(HistoricalEnrollmentService::class)->makePartial();
+        $service->shouldReceive('isFirstSemesterClass')->andReturn(true);
+        $service->shouldReceive('hasSpecialObstur')->andReturn(false);
+        $service->shouldReceive('calculateHistoricalStats')->andReturn([
+            'average' => 50.0,
+            'stddev' => 10.0,
+            'samples' => 3,
+            'years' => [2022, 2023, 2024],
+        ]);
+
+        // Subdimensionado: 30 inscritos vs média 50 (desvio = 40%)
+        $class = SchoolClass::factory()->create(['estmtr' => 30]);
+
+        $result = $service->calculateAdjustedDemand($class);
+
+        $this->assertTrue($result['applied']);
+        $this->assertEquals(80, $result['demand']); // 50 + 3 * 10
+        $this->assertNotNull($result['metadata']);
+        $this->assertEquals(50.0, $result['metadata']['average']);
+        $this->assertEquals(10.0, $result['metadata']['stddev']);
+
+        // Banco não deve ser alterado
+        $class->refresh();
+        $this->assertEquals(30, $class->estmtr);
+    }
+
+    /** @test */
+    public function it_applies_cap_to_adjusted_demand()
+    {
+        $service = Mockery::mock(HistoricalEnrollmentService::class)->makePartial();
+        $service->shouldReceive('isFirstSemesterClass')->andReturn(true);
+        $service->shouldReceive('hasSpecialObstur')->andReturn(false);
+        $service->shouldReceive('calculateHistoricalStats')->andReturn([
+            'average' => 60.0,
+            'stddev' => 10.0,
+            'samples' => 3,
+            'years' => [2022, 2023, 2024],
+        ]);
+
+        // Força o cap via reflection, já que o construtor já leu o padrão 100
+        $reflection = new \ReflectionClass(HistoricalEnrollmentService::class);
+        $capProperty = $reflection->getProperty('cap');
+        $capProperty->setAccessible(true);
+        $capProperty->setValue($service, 70);
+
+        $class = SchoolClass::factory()->create(['estmtr' => 10]);
+
+        $result = $service->calculateAdjustedDemand($class);
+
+        $this->assertTrue($result['applied']);
+        $this->assertEquals(70, $result['demand']); // 60 + 3*10 = 90, mas cap = 70
+    }
+
+    /** @test */
+    public function it_does_not_adjust_demand_when_deviation_is_within_threshold()
+    {
+        $service = Mockery::mock(HistoricalEnrollmentService::class)->makePartial();
+        $service->shouldReceive('isFirstSemesterClass')->andReturn(true);
+        $service->shouldReceive('hasSpecialObstur')->andReturn(false);
+        $service->shouldReceive('calculateHistoricalStats')->andReturn([
+            'average' => 100.0,
+            'stddev' => 5.0,
+            'samples' => 3,
+            'years' => [2022, 2023, 2024],
+        ]);
+
+        // 95 inscritos vs média 100 = 5% de desvio, abaixo do threshold padrão 7%
+        $class = SchoolClass::factory()->create(['estmtr' => 95]);
+
+        $result = $service->calculateAdjustedDemand($class);
+
+        $this->assertFalse($result['applied']);
+        $this->assertEquals(95, $result['demand']);
+    }
+
+    /** @test */
+    public function it_does_not_adjust_demand_for_non_first_semester_class()
+    {
+        $service = Mockery::mock(HistoricalEnrollmentService::class)->makePartial();
+        $service->shouldReceive('isFirstSemesterClass')->andReturn(false);
+
+        $class = SchoolClass::factory()->create(['estmtr' => 10]);
+
+        $result = $service->calculateAdjustedDemand($class);
+
+        $this->assertFalse($result['applied']);
+        $this->assertEquals(10, $result['demand']);
+    }
+
+    /** @test */
+    public function it_does_not_adjust_demand_when_insufficient_historical_samples()
+    {
+        $service = Mockery::mock(HistoricalEnrollmentService::class)->makePartial();
+        $service->shouldReceive('isFirstSemesterClass')->andReturn(true);
+        $service->shouldReceive('hasSpecialObstur')->andReturn(false);
+        $service->shouldReceive('calculateHistoricalStats')->andReturn([
+            'average' => 50.0,
+            'stddev' => 10.0,
+            'samples' => 1,
+            'years' => [2024],
+        ]);
+
+        $class = SchoolClass::factory()->create(['estmtr' => 10]);
+
+        $result = $service->calculateAdjustedDemand($class);
+
+        $this->assertFalse($result['applied']);
+        $this->assertEquals(10, $result['demand']);
+    }
+
+    /** @test */
+    public function it_uses_zero_stddev_when_only_one_sample_available()
+    {
+        $service = Mockery::mock(HistoricalEnrollmentService::class)->makePartial();
+        $service->shouldReceive('isFirstSemesterClass')->andReturn(true);
+        $service->shouldReceive('hasSpecialObstur')->andReturn(false);
+        $service->shouldReceive('calculateHistoricalStats')->andReturn([
+            'average' => 50.0,
+            'stddev' => 0.0,
+            'samples' => 2,
+            'years' => [2023, 2024],
+        ]);
+
+        $class = SchoolClass::factory()->create(['estmtr' => 10]);
+
+        $result = $service->calculateAdjustedDemand($class);
+
+        $this->assertTrue($result['applied']);
+        $this->assertEquals(50, $result['demand']); // 50 + 3*0
+    }
 }

--- a/tests/Unit/ProcessRoomDistributionTest.php
+++ b/tests/Unit/ProcessRoomDistributionTest.php
@@ -47,10 +47,10 @@ class ProcessRoomDistributionTest extends TestCase
 
         Http::assertSent(function ($request) use ($term, $room) {
             $data = $request->data();
-            $this->assertArrayHasKey('payload', $data);
-            $this->assertArrayHasKey('webhook_url', $data);
-            $this->assertArrayHasKey('progress_webhook_url', $data);
-            $this->assertEquals([$room->id], array_column($data['payload']['rooms'], 'id'));
+            $this->assertArrayHasKey('meta', $data);
+            $this->assertArrayHasKey('webhook_url', $data['meta']);
+            $this->assertArrayHasKey('progress_webhook_url', $data['meta']);
+            $this->assertEquals([$room->id], array_column($data['rooms'], 'id'));
             return true;
         });
 
@@ -129,7 +129,7 @@ class ProcessRoomDistributionTest extends TestCase
         $job->handle();
 
         Http::assertSent(function ($request) use ($external, $normal) {
-            $groupIds = array_column($request->data()['payload']['groups'], 'id');
+            $groupIds = array_column($request->data()['groups'], 'id');
             $this->assertNotContains($external->id, $groupIds);
             $this->assertContains($normal->id, $groupIds);
             return true;

--- a/tests/Unit/RoomAllocationPayloadBuilderTest.php
+++ b/tests/Unit/RoomAllocationPayloadBuilderTest.php
@@ -5,15 +5,23 @@ namespace Tests\Unit;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Services\RoomAllocationPayloadBuilder;
+use App\Services\HistoricalEnrollmentService;
 use App\Models\SchoolClass;
 use App\Models\SchoolTerm;
 use App\Models\Room;
 use App\Models\Fusion;
 use App\Models\ClassSchedule;
+use Mockery;
 
 class RoomAllocationPayloadBuilderTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
 
     /** @test */
     public function it_builds_payload_for_single_class_with_schedule()
@@ -1086,5 +1094,131 @@ class RoomAllocationPayloadBuilderTest extends TestCase
     public function it_bumps_schema_version_to_1_1_0()
     {
         $this->assertEquals('1.1.0', RoomAllocationPayloadBuilder::schemaVersion());
+    }
+
+    /** @test */
+    public function it_applies_historical_adjustment_to_freshmen_class_demand()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $course = \App\Models\Course::factory()->create([
+            'sufixo_codtur' => '45',
+        ]);
+
+        $courseInfo = \App\Models\CourseInformation::factory()->create([
+            'tipobg' => 'O',
+            'numsemidl' => '1',
+        ]);
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'codtur' => '202445',
+            'coddis' => 'MAC0110',
+            'tiptur' => 'Graduação',
+            'externa' => false,
+            'fusion_id' => null,
+            'estmtr' => 10,
+        ]);
+        $class->courseinformations()->attach($courseInfo);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $historicalServiceMock = Mockery::mock(HistoricalEnrollmentService::class);
+        $historicalServiceMock->shouldReceive('calculateAdjustedDemand')
+            ->andReturn([
+                'demand' => 80,
+                'applied' => true,
+                'metadata' => [
+                    'average' => 70.0,
+                    'stddev' => 5.0,
+                    'cap' => 100,
+                ],
+            ]);
+
+        $builder = new RoomAllocationPayloadBuilder($historicalServiceMock);
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertEquals(80, $group['demand']);
+        $this->assertTrue($group['historical_adjustment_applied']);
+        $this->assertNotNull($group['historical_adjustment_metadata']);
+        $this->assertEquals(80, $group['historical_adjustment_metadata'][0]['adjusted_demand']);
+    }
+
+    /** @test */
+    public function it_keeps_original_demand_when_historical_adjustment_is_not_applied()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'estmtr' => 55,
+        ]);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $historicalServiceMock = Mockery::mock(HistoricalEnrollmentService::class);
+        $historicalServiceMock->shouldReceive('calculateAdjustedDemand')
+            ->andReturn([
+                'demand' => 55,
+                'applied' => false,
+                'metadata' => null,
+            ]);
+
+        $builder = new RoomAllocationPayloadBuilder($historicalServiceMock);
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertEquals(55, $group['demand']);
+        $this->assertFalse($group['historical_adjustment_applied']);
+        $this->assertNull($group['historical_adjustment_metadata']);
+    }
+
+    /** @test */
+    public function it_does_not_persist_historical_adjustment_to_database()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $course = \App\Models\Course::factory()->create([
+            'sufixo_codtur' => '45',
+        ]);
+
+        $courseInfo = \App\Models\CourseInformation::factory()->create([
+            'tipobg' => 'O',
+            'numsemidl' => '1',
+        ]);
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'codtur' => '202445',
+            'coddis' => 'MAC0110',
+            'tiptur' => 'Graduação',
+            'externa' => false,
+            'fusion_id' => null,
+            'estmtr' => 10,
+        ]);
+        $class->courseinformations()->attach($courseInfo);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $historicalServiceMock = Mockery::mock(HistoricalEnrollmentService::class);
+        $historicalServiceMock->shouldReceive('calculateAdjustedDemand')
+            ->andReturn([
+                'demand' => 80,
+                'applied' => true,
+                'metadata' => ['average' => 70.0],
+            ]);
+
+        $builder = new RoomAllocationPayloadBuilder($historicalServiceMock);
+        $builder->build($term, [$room->id]);
+
+        $class->refresh();
+        $this->assertEquals(10, $class->estmtr);
     }
 }


### PR DESCRIPTION
## Summary

Closes #55.

This PR applies historical demand estimation for first-semester classes in the solver payload, without persisting fictitious values into the `estmtr` column.

### What changed

- Added `HistoricalEnrollmentService` to compute historical enrollment stats (mean and standard deviation) and an adjusted demand using `mean + 3 * stddev`, capped by `HISTORICAL_CAP` (default 100).
- Added new config keys in `config/alocacao.php`:
  - `historical_estimation_method`
  - `historical_stddev_multiplier`
  - `historical_cap`
- Documented the new environment variables in `.env.example`.
- Updated `RoomAllocationPayloadBuilder` to apply the adjusted demand only in the solver payload, preserving the real `estmtr` in the database.
- The adjustment is triggered only when the current estimated demand is below a configurable percentage of the historical average.
- Excludes MAE0116 and classes with special observations (`obstur`) from the adjustment.
- Added unit tests for `HistoricalEnrollmentService` and `RoomAllocationPayloadBuilder`.
- Fixed outdated tests in `ProcessRoomDistributionTest` and `DistributionFlowTest`.
- Configured `phpunit.xml` to use SQLite in-memory, preventing test data from polluting the development MySQL database.

### Test procedure

- Ran the full PHPUnit suite: 167 tests passed.
- Verified that `estmtr` is not modified when the solver payload is generated.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other
