### PR TITLE
feat(allocation-states): implement save/load allocation states system

### DIFF
--- a/app/Http/Controllers/AllocationStateController.php
+++ b/app/Http/Controllers/AllocationStateController.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreAllocationStateRequest;
+use App\Models\AllocationState;
+use App\Models\SchoolTerm;
+use App\Services\AllocationStateService;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+use Session;
+
+class AllocationStateController extends Controller
+{
+    /**
+     * Display a listing of allocation states for the current school term.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index()
+    {
+        if (!Auth::check() || !Auth::user()->hasRole(["Administrador", "Operador"])) {
+            abort(403);
+        }
+
+        $schoolterm = SchoolTerm::getLatest();
+
+        $states = AllocationState::whereBelongsTo($schoolterm)
+            ->orderByDesc('created_at')
+            ->get();
+
+        $cached = Cache::get("allocation:{$schoolterm->id}");
+        $isSolving = ($cached['status'] ?? '') === 'solving';
+
+        return response()->json([
+            'states' => $states,
+            'is_solving' => $isSolving,
+        ]);
+    }
+
+    /**
+     * Store a new manual allocation state.
+     *
+     * @param StoreAllocationStateRequest $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function store(StoreAllocationStateRequest $request)
+    {
+        if (!Auth::check() || !Auth::user()->hasRole(["Administrador", "Operador"])) {
+            abort(403);
+        }
+
+        $schoolterm = SchoolTerm::getLatest();
+
+        if (! $schoolterm) {
+            Session::put("alert-warning", "Não há semestre letivo ativo para salvar o estado.");
+            return back();
+        }
+
+        $name = $request->input('name') ?: now()->format('d/m/Y H:i:s');
+
+        $state = AllocationStateService::capture($schoolterm, $name);
+
+        Session::put("alert-info", "Estado '{$state->name}' salvo com sucesso.");
+        return back();
+    }
+
+    /**
+     * Restore a previously saved allocation state.
+     *
+     * @param AllocationState $state
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function restore(AllocationState $state)
+    {
+        if (!Auth::check() || !Auth::user()->hasRole(["Administrador", "Operador"])) {
+            abort(403);
+        }
+
+        $schoolterm = SchoolTerm::getLatest();
+
+        if (! $schoolterm) {
+            Session::put("alert-warning", "Não há semestre letivo ativo.");
+            return back();
+        }
+
+        $cached = Cache::get("allocation:{$schoolterm->id}");
+        if (($cached['status'] ?? '') === 'solving') {
+            Session::put("alert-warning", "Não é possível carregar um estado enquanto o solver estiver em execução.");
+            return back();
+        }
+
+        $result = AllocationStateService::restore($state);
+
+        $message = "Estado restaurado com sucesso!";
+        if ($result['missing'] > 0 || $result['unassigned'] > 0) {
+            $message = "Estado restaurado! Aviso: {$result['missing']} turmas do save não existem mais e foram ignoradas; {$result['unassigned']} novas turmas ficaram sem sala.";
+        }
+
+        Session::put("alert-info", $message);
+        return back();
+    }
+
+    /**
+     * Remove the specified allocation state.
+     *
+     * @param AllocationState $state
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function destroy(AllocationState $state)
+    {
+        if (!Auth::check() || !Auth::user()->hasRole(["Administrador", "Operador"])) {
+            abort(403);
+        }
+
+        $state->delete();
+
+        Session::put("alert-info", "Estado removido com sucesso.");
+        return back();
+    }
+}

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -29,6 +29,7 @@ use App\Models\SchoolClass;
 use App\Models\CourseInformation;
 use App\Models\Fusion;
 use App\Services\ReservationApiService;
+use App\Services\AllocationStateService;
 use Illuminate\Support\Facades\Auth;
 
 
@@ -496,6 +497,11 @@ class RoomController extends Controller
         $rooms_ids = $validated["rooms_id"];
 
         $schoolterm = SchoolTerm::getLatest();
+
+        AllocationStateService::capture(
+            $schoolterm,
+            'Pré-Esvaziamento - ' . now()->format('d/m/Y H:i:s')
+        );
 
         $schoolclasses = SchoolClass::whereBelongsTo($schoolterm)->whereHas("room", function($query)use($rooms_ids){
             $query->whereIn("id", $rooms_ids);

--- a/app/Http/Requests/StoreAllocationStateRequest.php
+++ b/app/Http/Requests/StoreAllocationStateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreAllocationStateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/app/Jobs/ProcessRoomDistribution.php
+++ b/app/Jobs/ProcessRoomDistribution.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\Models\SchoolTerm;
 use App\Models\SolverLog;
 use App\Services\RoomAllocationPayloadBuilder;
+use App\Services\AllocationStateService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -120,13 +121,20 @@ class ProcessRoomDistribution implements ShouldQueue, ShouldBeUnique
         );
 
         // Persist the payload for later debugging via admin view
-        SolverLog::create([
+        $solverLog = SolverLog::create([
             'school_term_id' => $this->schoolTermId,
             'job_id' => $jobId,
             'payload' => $payload,
             'status' => 'solving',
             'dispatched_at' => now(),
         ]);
+
+        // Auto-save the current allocation state before the solver runs
+        AllocationStateService::capture(
+            $term,
+            'Pré-Solver - ' . now()->format('d/m/Y H:i:s'),
+            $solverLog->id
+        );
 
         Log::info('ProcessRoomDistribution: job dispatched successfully', [
             'school_term_id' => $this->schoolTermId,

--- a/app/Models/AllocationState.php
+++ b/app/Models/AllocationState.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AllocationState extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'school_term_id',
+        'name',
+        'allocations',
+        'solver_log_id',
+    ];
+
+    protected $casts = [
+        'allocations' => 'array',
+    ];
+
+    public function schoolTerm()
+    {
+        return $this->belongsTo(SchoolTerm::class);
+    }
+
+    public function solverLog()
+    {
+        return $this->belongsTo(SolverLog::class);
+    }
+}

--- a/app/Services/AllocationStateService.php
+++ b/app/Services/AllocationStateService.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AllocationState;
+use App\Models\SchoolClass;
+use App\Models\SchoolTerm;
+
+class AllocationStateService
+{
+    /**
+     * Capture the current allocation state for a school term.
+     *
+     * @param SchoolTerm $term
+     * @param string $name
+     * @param int|null $solverLogId
+     * @return AllocationState
+     */
+    public static function capture(SchoolTerm $term, string $name, ?int $solverLogId = null): AllocationState
+    {
+        $allocations = [];
+
+        $schoolClasses = SchoolClass::whereBelongsTo($term)
+            ->with(['room', 'fusion.master.room', 'fusion.schoolclasses.room'])
+            ->get();
+
+        foreach ($schoolClasses as $schoolClass) {
+            $allocations[$schoolClass->id] = self::resolveRoomId($schoolClass);
+        }
+
+        return AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => $name,
+            'allocations' => $allocations,
+            'solver_log_id' => $solverLogId,
+        ]);
+    }
+
+    /**
+     * Restore a previously captured allocation state.
+     *
+     * @param AllocationState $state
+     * @return array{missing: int, unassigned: int}
+     */
+    public static function restore(AllocationState $state): array
+    {
+        $term = SchoolTerm::getLatest();
+
+        $savedAllocations = $state->allocations ?? [];
+        $missingCount = 0;
+
+        $currentClasses = SchoolClass::whereBelongsTo($term)
+            ->with('fusion.master')
+            ->get()
+            ->keyBy('id');
+
+        foreach ($savedAllocations as $schoolClassId => $roomId) {
+            $schoolClass = $currentClasses->get($schoolClassId);
+
+            if (! $schoolClass) {
+                $missingCount++;
+                continue;
+            }
+
+            if ($schoolClass->fusion_id && $schoolClass->fusion && $schoolClass->fusion->master) {
+                $master = $schoolClass->fusion->master;
+                $master->room_id = $roomId;
+                $master->save();
+            } else {
+                $schoolClass->room_id = $roomId;
+                $schoolClass->save();
+            }
+        }
+
+        $unassignedCount = SchoolClass::whereBelongsTo($term)->whereNull('room_id')->count();
+
+        return [
+            'missing' => $missingCount,
+            'unassigned' => $unassignedCount,
+        ];
+    }
+
+    /**
+     * Resolve the room id that should be saved for a school class.
+     *
+     * For fused classes, prefer the master's room. If the master has no room,
+     * fall back to any child class that has a room.
+     *
+     * @param SchoolClass $schoolClass
+     * @return int|null
+     */
+    private static function resolveRoomId(SchoolClass $schoolClass): ?int
+    {
+        if ($schoolClass->fusion_id && $schoolClass->fusion) {
+            $master = $schoolClass->fusion->master;
+
+            if ($master && $master->room_id) {
+                return $master->room_id;
+            }
+
+            foreach ($schoolClass->fusion->schoolclasses as $child) {
+                if ($child->room_id) {
+                    return $child->room_id;
+                }
+            }
+
+            return null;
+        }
+
+        return $schoolClass->room_id;
+    }
+}

--- a/app/Services/AllocationStateService.php
+++ b/app/Services/AllocationStateService.php
@@ -72,7 +72,10 @@ class AllocationStateService
             }
         }
 
-        $unassignedCount = SchoolClass::whereBelongsTo($term)->whereNull('room_id')->count();
+        $unassignedCount = SchoolClass::whereBelongsTo($term)
+            ->where('externa', false)
+            ->whereNull('room_id')
+            ->count();
 
         return [
             'missing' => $missingCount,

--- a/database/migrations/2026_06_17_180000_create_allocation_states_table.php
+++ b/database/migrations/2026_06_17_180000_create_allocation_states_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateAllocationStatesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('allocation_states', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('school_term_id')->constrained('school_terms')->cascadeOnDelete();
+            $table->string('name');
+            $table->json('allocations');
+            $table->foreignId('solver_log_id')->nullable()->constrained('solver_logs')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('allocation_states');
+    }
+}

--- a/resources/views/rooms/index.blade.php
+++ b/resources/views/rooms/index.blade.php
@@ -98,6 +98,10 @@
                                     Verificar Resultado Manualmente
                                 </button>
                             </form>
+
+                            <button class="btn btn-outline-info" id="btn-allocation-states" data-toggle="modal" data-target="#allocationStatesModal">
+                                Histórico de Estados
+                            </button>
                         </div>
                     <br>
 
@@ -209,6 +213,54 @@
             @else
                 <p class="text-center">Não há salas cadastradas</p>
             @endif
+        </div>
+    </div>
+</div>
+
+<!-- Modal Gerenciador de Alocações -->
+<div class="modal fade" id="allocationStatesModal" tabindex="-1" role="dialog" aria-labelledby="allocationStatesModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="allocationStatesModalLabel">Gerenciador de Alocações</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Fechar">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <form id="saveAllocationStateForm" action="{{ route('allocation-states.store') }}" method="POST">
+                    @csrf
+                    <div class="form-group">
+                        <label for="allocation_state_name">Nome do estado</label>
+                        <input type="text" class="form-control" id="allocation_state_name" name="name"
+                               placeholder="Ex: Antes da reunião de departamento">
+                    </div>
+                    <button type="submit" class="btn btn-primary mb-3">Salvar Estado Atual</button>
+                </form>
+
+                <hr>
+
+                <h6>Estados salvos</h6>
+                <div class="table-responsive">
+                    <table class="table table-sm table-bordered table-hover" id="allocationStatesTable">
+                        <thead>
+                            <tr>
+                                <th>Nome</th>
+                                <th>Data</th>
+                                <th>Ações</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td colspan="3" class="text-center">Carregando...</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Fechar</button>
+            </div>
         </div>
     </div>
 </div>
@@ -406,6 +458,59 @@ $( function() {
         });
     }
     setTimeout( progressDistribution, 50 );
+
+    function loadAllocationStates() {
+        $.ajax({
+            url: "{{ route('allocation-states.index') }}",
+            dataType: 'json',
+            success: function(data) {
+                var tbody = $('#allocationStatesTable tbody');
+                tbody.empty();
+
+                if (data.states.length === 0) {
+                    tbody.append('<tr><td colspan="3" class="text-center">Nenhum estado salvo.</td></tr>');
+                    return;
+                }
+
+                data.states.forEach(function(state) {
+                    var disabled = data.is_solving ? 'disabled' : '';
+                    var row = '<tr>' +
+                        '<td>' + escapeHtml(state.name) + '</td>' +
+                        '<td>' + escapeHtml(state.created_at) + '</td>' +
+                        '<td>' +
+                            '<form style="display: inline;" action="/allocation-states/' + state.id + '/restore" method="POST">' +
+                                '@csrf' +
+                                '<button type="submit" class="btn btn-sm btn-outline-success" ' + disabled + '>Carregar</button>' +
+                            '</form> ' +
+                            '<form style="display: inline;" action="/allocation-states/' + state.id + '" method="POST">' +
+                                '@csrf' +
+                                '@method('DELETE')' +
+                                '<button type="submit" class="btn btn-sm btn-outline-danger">Excluir</button>' +
+                            '</form>' +
+                        '</td>' +
+                    '</tr>';
+                    tbody.append(row);
+                });
+            },
+            error: function() {
+                $('#allocationStatesTable tbody').html('<tr><td colspan="3" class="text-center text-danger">Erro ao carregar estados.</td></tr>');
+            }
+        });
+    }
+
+    function escapeHtml(text) {
+        if (!text) return '';
+        return text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
+    $('#allocationStatesModal').on('shown.bs.modal', function () {
+        loadAllocationStates();
+    });
 });
 </script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\CourseInformationController;
 use App\Http\Controllers\CurriculumController;
 use App\Http\Controllers\SpecialOfferController;
 use App\Http\Controllers\SolverLogController;
+use App\Http\Controllers\AllocationStateController;
 
 /*
 |--------------------------------------------------------------------------
@@ -62,6 +63,11 @@ Route::post('/rooms/distribution/stop', [RoomController::class, 'stopDistributio
 Route::post('/rooms/distribution/fallback', [RoomController::class, 'fallbackDistribution'])->name('rooms.distribution.fallback');
 Route::get('/rooms/dissociate/{schoolclass}', [RoomController::class, 'dissociate'])->name('rooms.dissociate');
 Route::resource('rooms', RoomController::class);
+
+Route::get('/allocation-states', [AllocationStateController::class, 'index'])->name('allocation-states.index');
+Route::post('/allocation-states', [AllocationStateController::class, 'store'])->name('allocation-states.store');
+Route::post('/allocation-states/{state}/restore', [AllocationStateController::class, 'restore'])->name('allocation-states.restore');
+Route::delete('/allocation-states/{state}', [AllocationStateController::class, 'destroy'])->name('allocation-states.destroy');
 
 Route::get('/fusions/disjoint/{schoolclass}', [FusionController::class, 'disjoint'])->name('fusions.disjoint');
 Route::resource('fusions', FusionController::class);

--- a/tests/Feature/AllocationStateTest.php
+++ b/tests/Feature/AllocationStateTest.php
@@ -206,6 +206,41 @@ class AllocationStateTest extends TestCase
     }
 
     /** @test */
+    public function restore_does_not_count_external_classes_as_unassigned()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $existingClass = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $room->id,
+        ]);
+
+        $state = \App\Models\AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'External Save',
+            'allocations' => [$existingClass->id => $room->id],
+        ]);
+
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+            'externa' => false,
+        ]);
+
+        SchoolClass::factory()->external()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+        ]);
+
+        $response = $this->actingAsOperator()->post("/allocation-states/{$state->id}/restore");
+
+        $response->assertSessionHas('alert-info', function ($message) {
+            return str_contains($message, '1 novas turmas ficaram sem sala');
+        });
+    }
+
+    /** @test */
     public function restore_warns_about_missing_classes_and_unassigned_classes()
     {
         $term = SchoolTerm::factory()->create();

--- a/tests/Feature/AllocationStateTest.php
+++ b/tests/Feature/AllocationStateTest.php
@@ -1,0 +1,370 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ClassSchedule;
+use App\Models\Fusion;
+use App\Models\Room;
+use App\Models\SchoolClass;
+use App\Models\SchoolTerm;
+use App\Models\SolverLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class AllocationStateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['alocacao.solver.url' => 'http://solver.test']);
+        config(['alocacao.solver.api_token' => 'test-token']);
+        Cache::flush();
+    }
+
+    private function actingAsOperator(): self
+    {
+        Role::firstOrCreate(['name' => 'Operador', 'guard_name' => 'web']);
+        $user = User::factory()->create();
+        $user->assignRole('Operador');
+        return $this->actingAs($user);
+    }
+
+    private function actingAsAdmin(): self
+    {
+        Role::firstOrCreate(['name' => 'Administrador', 'guard_name' => 'web']);
+        $user = User::factory()->create();
+        $user->assignRole('Administrador');
+        return $this->actingAs($user);
+    }
+
+    /** @test */
+    public function operator_can_save_allocation_state_manually()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $room->id,
+        ]);
+
+        $response = $this->actingAsOperator()
+            ->post('/allocation-states', ['name' => 'Meu Save']);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('alert-info');
+
+        $this->assertDatabaseHas('allocation_states', [
+            'school_term_id' => $term->id,
+            'name' => 'Meu Save',
+        ]);
+
+        $state = \App\Models\AllocationState::first();
+        $this->assertArrayHasKey($class->id, $state->allocations);
+        $this->assertEquals($room->id, $state->allocations[$class->id]);
+    }
+
+    /** @test */
+    public function manual_save_uses_timestamp_when_name_is_empty()
+    {
+        $term = SchoolTerm::factory()->create();
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => Room::factory()->create()->id,
+        ]);
+
+        $response = $this->actingAsOperator()->post('/allocation-states');
+
+        $response->assertRedirect();
+        $this->assertCount(1, \App\Models\AllocationState::all());
+        $this->assertMatchesRegularExpression('/\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}/', \App\Models\AllocationState::first()->name);
+    }
+
+    /** @test */
+    public function save_captures_master_room_for_fused_classes()
+    {
+        $term = SchoolTerm::factory()->create();
+        $masterRoom = Room::factory()->create();
+        $childRoom = Room::factory()->create();
+
+        $master = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $masterRoom->id,
+        ]);
+        $child = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $childRoom->id,
+        ]);
+
+        $fusion = Fusion::create(['master_id' => $master->id]);
+        $master->fusion_id = $fusion->id;
+        $master->save();
+        $child->fusion_id = $fusion->id;
+        $child->save();
+
+        $this->actingAsOperator()->post('/allocation-states', ['name' => 'Fusion Save']);
+
+        $state = \App\Models\AllocationState::first();
+        $this->assertEquals($masterRoom->id, $state->allocations[$master->id]);
+        $this->assertEquals($masterRoom->id, $state->allocations[$child->id]);
+    }
+
+    /** @test */
+    public function save_falls_back_to_child_room_when_master_has_no_room()
+    {
+        $term = SchoolTerm::factory()->create();
+        $childRoom = Room::factory()->create();
+
+        $master = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+        ]);
+        $child = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $childRoom->id,
+        ]);
+
+        $fusion = Fusion::create(['master_id' => $master->id]);
+        $master->fusion_id = $fusion->id;
+        $master->save();
+        $child->fusion_id = $fusion->id;
+        $child->save();
+
+        $this->actingAsOperator()->post('/allocation-states', ['name' => 'Fallback Save']);
+
+        $state = \App\Models\AllocationState::first();
+        $this->assertEquals($childRoom->id, $state->allocations[$master->id]);
+        $this->assertEquals($childRoom->id, $state->allocations[$child->id]);
+    }
+
+    /** @test */
+    public function operator_can_restore_allocation_state()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+        ]);
+
+        $state = \App\Models\AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Restore Save',
+            'allocations' => [$class->id => $room->id],
+        ]);
+
+        $response = $this->actingAsOperator()
+            ->post("/allocation-states/{$state->id}/restore");
+
+        $response->assertRedirect();
+        $response->assertSessionHas('alert-info');
+
+        $this->assertDatabaseHas('school_classes', [
+            'id' => $class->id,
+            'room_id' => $room->id,
+        ]);
+    }
+
+    /** @test */
+    public function restore_applies_room_to_fusion_master()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $master = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+        ]);
+        $child = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+        ]);
+
+        $fusion = Fusion::create(['master_id' => $master->id]);
+        $master->fusion_id = $fusion->id;
+        $master->save();
+        $child->fusion_id = $fusion->id;
+        $child->save();
+
+        $state = \App\Models\AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Fusion Restore',
+            'allocations' => [$child->id => $room->id],
+        ]);
+
+        $this->actingAsOperator()->post("/allocation-states/{$state->id}/restore");
+
+        $this->assertDatabaseHas('school_classes', [
+            'id' => $master->id,
+            'room_id' => $room->id,
+        ]);
+    }
+
+    /** @test */
+    public function restore_warns_about_missing_classes_and_unassigned_classes()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $existingClass = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $room->id,
+        ]);
+
+        $state = \App\Models\AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Stale Save',
+            'allocations' => [
+                $existingClass->id => $room->id,
+                99999 => $room->id,
+            ],
+        ]);
+
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+        ]);
+
+        $response = $this->actingAsOperator()->post("/allocation-states/{$state->id}/restore");
+
+        $response->assertSessionHas('alert-info', function ($message) {
+            return str_contains($message, '1 turmas do save não existem mais')
+                && str_contains($message, '1 novas turmas ficaram sem sala');
+        });
+    }
+
+    /** @test */
+    public function index_returns_states_and_solving_status()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = \App\Models\AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Listed Save',
+            'allocations' => [],
+        ]);
+
+        Cache::put("allocation:{$term->id}", ['status' => 'solving'], now()->addHour());
+
+        $response = $this->actingAsOperator()->get('/allocation-states');
+
+        $response->assertOk();
+        $response->assertJsonPath('states.0.id', $state->id);
+        $response->assertJsonPath('is_solving', true);
+    }
+
+    /** @test */
+    public function restore_is_blocked_while_solver_is_running()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = \App\Models\AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Blocked Save',
+            'allocations' => [],
+        ]);
+
+        Cache::put("allocation:{$term->id}", ['status' => 'solving'], now()->addHour());
+
+        $response = $this->actingAsOperator()->post("/allocation-states/{$state->id}/restore");
+
+        $response->assertRedirect();
+        $response->assertSessionHas('alert-warning');
+    }
+
+    /** @test */
+    public function guests_cannot_access_allocation_state_routes()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = \App\Models\AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Save',
+            'allocations' => [],
+        ]);
+
+        $this->get('/allocation-states')->assertForbidden();
+        $this->post('/allocation-states')->assertForbidden();
+        $this->post("/allocation-states/{$state->id}/restore")->assertForbidden();
+        $this->delete("/allocation-states/{$state->id}")->assertForbidden();
+    }
+
+    /** @test */
+    public function operator_can_delete_allocation_state()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = \App\Models\AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'To Delete',
+            'allocations' => [],
+        ]);
+
+        $response = $this->actingAsOperator()->delete("/allocation-states/{$state->id}");
+
+        $response->assertRedirect();
+        $response->assertSessionHas('alert-info');
+        $this->assertDatabaseMissing('allocation_states', ['id' => $state->id]);
+    }
+
+    /** @test */
+    public function emptying_rooms_creates_pre_emptying_state()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+        SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $room->id,
+        ]);
+
+        $response = $this->actingAsOperator()
+            ->patch('/rooms/empty', ['rooms_id' => [$room->id]]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('allocation_states', [
+            'school_term_id' => $term->id,
+        ]);
+
+        $state = \App\Models\AllocationState::first();
+        $this->assertStringStartsWith('Pré-Esvaziamento', $state->name);
+        $this->assertNull($state->solver_log_id);
+    }
+
+    /** @test */
+    public function dispatching_distribution_creates_pre_solver_state_linked_to_solver_log()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+            'externa' => false,
+        ]);
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        Http::fake([
+            'http://solver.test/api/v1/solve' => Http::response([
+                'job_id' => 'pre-solver-123',
+            ], 202),
+        ]);
+
+        $this->actingAsOperator()
+            ->patch('/rooms/distributes', ['rooms_id' => [$room->id]]);
+
+        $this->assertDatabaseHas('solver_logs', [
+            'job_id' => 'pre-solver-123',
+        ]);
+
+        $solverLog = SolverLog::where('job_id', 'pre-solver-123')->first();
+
+        $this->assertDatabaseHas('allocation_states', [
+            'school_term_id' => $term->id,
+            'solver_log_id' => $solverLog->id,
+        ]);
+
+        $state = \App\Models\AllocationState::where('solver_log_id', $solverLog->id)->first();
+        $this->assertStringStartsWith('Pré-Solver', $state->name);
+    }
+}


### PR DESCRIPTION
## Summary

Implementa o sistema de **Save States** para alocação de salas, permitindo que operadores e administradores salvem, restaurem e gerenciem estados anteriores das alocações.

## Related Issue

Closes #61

## Changes Made

- **Banco de dados**: criada a tabela `allocation_states` com `school_term_id`, `name`, `allocations` (JSON), `solver_log_id` (nullable) e timestamps.
- **Modelo**: adicionado `App\Models\AllocationState` com relacionamentos `schoolTerm` e `solverLog`.
- **Service**: adicionado `App\Services\AllocationStateService` com:
  - `capture()`: salva o mapeamento `school_class_id -> room_id`, priorizando a sala do `master` em fusões e fazendo fallback para turmas filhas.
  - `restore()`: reaplica o mapeamento, replica a sala para o `master` em fusões e reporta turmas ausentes/novas sem sala.
- **Controller**: adicionado `AllocationStateController` com endpoints JSON/listagem, salvar manual, carregar e excluir.
- **Rotas**: registradas em `routes/web.php` protegidas pelos papéis `Administrador` e `Operador`.
- **UI**: adicionado botão "Histórico de Estados" na tela `rooms.index` com modal Bootstrap para listar, salvar e restaurar estados.
- **Auto-saves**:
  - `Pré-Esvaziamento - [Timestamp]` antes da ação "Esvaziar Salas".
  - `Pré-Solver - [Timestamp]` antes do job do solver, vinculado ao `SolverLog` gerado.
- **Bloqueio de concorrência**: o carregamento é bloqueado no backend quando o cache `allocation:{schoolterm_id}` está com status `solving`.
- **Testes**: adicionada a suite `tests/Feature/AllocationStateTest.php` com 13 testes cobrindo saves manuais, restauração, fusões, avisos de desintegração, bloqueio de concorrência, auto-saves e permissões.

## Acceptance Criteria

- [x] Tabela `allocation_states` criada.
- [x] Modal "Gerenciador de Alocações" na `rooms.index`.
- [x] Salvamento manual de estado com nome padrão de timestamp.
- [x] JSON segue regra de dobradinhas (master → filhas).
- [x] Carregamento restaura mapeamento e replica sala para fusões.
- [x] Aviso de desintegração da malha.
- [x] Bloqueio de carregamento durante execução do solver.
- [x] Auto-save antes de "Esvaziar Salas".
- [x] Auto-save `Pré-Solver` vinculado ao `SolverLog`.
- [x] Rotas protegidas para `Administrador` e `Operador`.
- [x] Testes de feature passando.

## Test Procedure

```bash
# Rodar a suite completa dentro do container Docker
docker exec alocacao-app php artisan test
```

Resultado: **180 passed**.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Pre-flight Checklist

- [x] Branch criada a partir do `master` atualizado.
- [x] Código testado localmente (`php artisan test`).
- [x] Migration aplicada no banco de desenvolvimento.
- [x] Commit segue formato convencional.
- [x] PR vinculado à issue #61.
