### PR TITLE
feat(solver): modal de configuração transientes do solver e comparação pós-solver

### DIFF
--- a/app/Http/Controllers/AllocationResultWebhookController.php
+++ b/app/Http/Controllers/AllocationResultWebhookController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\AllocationState;
 use App\Models\SchoolClass;
+use App\Models\SchoolTerm;
 use App\Models\SolverLog;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
@@ -136,9 +138,11 @@ class AllocationResultWebhookController extends Controller
             );
         }
 
+        $comparisonMessage = $this->buildComparisonMessage($jobId, $schoolTermId);
+
         $activeJob['status'] = 'completed';
         $activeJob['progress'] = 100;
-        $activeJob['message'] = 'Distribuição concluída';
+        $activeJob['message'] = $comparisonMessage ?? 'Distribuição concluída';
         $activeJob['finished_at'] = now()->toIso8601String();
         $activeJob['assignments_count'] = $autoCount;
         $activeJob['unassigned_count'] = count($unassignedGroups) - $manualCount;
@@ -163,6 +167,63 @@ class AllocationResultWebhookController extends Controller
         ]);
 
         return response()->json(['message' => 'Results applied'], 200);
+    }
+
+    /**
+     * Build a rich comparison message between the pre-solver allocation state
+     * and the current state after the solver result has been applied.
+     */
+    private function buildComparisonMessage(string $jobId, int $schoolTermId): ?string
+    {
+        $solverLog = SolverLog::where('job_id', $jobId)->first();
+
+        if (! $solverLog) {
+            return null;
+        }
+
+        $preState = AllocationState::where('solver_log_id', $solverLog->id)
+            ->where('school_term_id', $schoolTermId)
+            ->latest()
+            ->first();
+
+        if (! $preState) {
+            return null;
+        }
+
+        $preAllocations = $preState->allocations ?? [];
+
+        $currentClasses = SchoolClass::whereBelongsTo(SchoolTerm::find($schoolTermId))
+            ->where('externa', false)
+            ->get()
+            ->keyBy('id');
+
+        $newAllocations = 0;
+        $changedRooms = 0;
+
+        foreach ($currentClasses as $id => $schoolClass) {
+            $currentRoomId = $schoolClass->room_id;
+            $previousRoomId = $preAllocations[$id] ?? null;
+
+            if ($previousRoomId === null && $currentRoomId !== null) {
+                $newAllocations++;
+            } elseif ($previousRoomId !== null && $currentRoomId !== null && (int) $previousRoomId !== (int) $currentRoomId) {
+                $changedRooms++;
+            }
+        }
+
+        if ($newAllocations === 0 && $changedRooms === 0) {
+            return 'Distribuição concluída: nenhuma alteração em relação ao estado pré-solver.';
+        }
+
+        $parts = [];
+        if ($newAllocations > 0) {
+            $parts[] = "{$newAllocations} turma(s) nova(s) foi(ram) alocada(s)";
+        }
+        if ($changedRooms > 0) {
+            $parts[] = "{$changedRooms} turma(s) mudou(aram) de sala";
+        }
+
+        return 'Distribuição concluída: ' . implode(', ', $parts) . '.';
     }
 
     /**

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -261,7 +261,11 @@ class RoomController extends Controller
             return back();
         }
 
-        ProcessRoomDistribution::dispatch($schoolterm->id, $validated['rooms_id']);
+        ProcessRoomDistribution::dispatch(
+            $schoolterm->id,
+            $validated['rooms_id'],
+            $validated['solver_config'] ?? []
+        );
 
         Session::put("alert-info", "A distribuição de salas foi iniciada. Acompanhe o progresso na barra acima.");
         return back();

--- a/app/Http/Requests/DistributesRoomRequest.php
+++ b/app/Http/Requests/DistributesRoomRequest.php
@@ -17,17 +17,62 @@ class DistributesRoomRequest extends FormRequest
     }
 
     /**
+     * Prepare the data for validation.
+     *
+     * Merge config defaults so the job always receives a complete solver_config
+     * even when the modal sends only a subset of fields.
+     */
+    protected function prepareForValidation()
+    {
+        $defaults = array_merge(
+            config('alocacao.room_allocation', []),
+            [
+                'historical_estimation_method' => config('alocacao.historical_estimation_method', 'average_plus_stddev'),
+                'historical_threshold_percent' => config('alocacao.historical_threshold_percent', 7.0),
+                'historical_lookback_years' => config('alocacao.historical_lookback_years', 5),
+                'historical_min_years' => config('alocacao.historical_min_years', 2),
+                'historical_cap' => config('alocacao.historical_cap', 100),
+                'historical_stddev_multiplier' => config('alocacao.historical_stddev_multiplier', 3.0),
+            ]
+        );
+
+        $this->merge([
+            'solver_config' => array_merge(
+                $defaults,
+                $this->input('solver_config', [])
+            ),
+        ]);
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array
      */
     public function rules()
     {
-        $rules = [
+        return [
             'rooms_id' => 'required|array',
             'rooms_id.*' => 'required|numeric',
-        ];
 
-        return $rules;
+            'solver_config' => 'nullable|array',
+
+            'solver_config.strict_capacity' => 'nullable|boolean',
+            'solver_config.block_b_restriction_for_pos' => 'nullable|boolean',
+            'solver_config.block_a_restriction_for_freshmen' => 'nullable|boolean',
+
+            'solver_config.undergrad_in_block_a_penalty' => 'nullable|numeric',
+            'solver_config.pos_in_block_b_penalty' => 'nullable|numeric',
+            'solver_config.wasted_seats_weight' => 'nullable|numeric',
+            'solver_config.unassigned_penalty' => 'nullable|numeric',
+            'solver_config.priority_weight' => 'nullable|numeric',
+
+            'solver_config.historical_estimation_method' => 'nullable|in:average_plus_stddev,none',
+            'solver_config.historical_threshold_percent' => 'nullable|numeric|min:0',
+            'solver_config.historical_lookback_years' => 'nullable|integer|min:1',
+            'solver_config.historical_min_years' => 'nullable|integer|min:1',
+            'solver_config.historical_cap' => 'nullable|integer|min:1',
+            'solver_config.historical_stddev_multiplier' => 'nullable|numeric|min:0',
+        ];
     }
 }

--- a/app/Jobs/ProcessRoomDistribution.php
+++ b/app/Jobs/ProcessRoomDistribution.php
@@ -22,6 +22,7 @@ class ProcessRoomDistribution implements ShouldQueue, ShouldBeUnique
 
     public int $schoolTermId;
     public array $roomIds;
+    public array $solverConfig;
 
     public int $timeout = 60;
     public int $tries = 3;
@@ -30,10 +31,11 @@ class ProcessRoomDistribution implements ShouldQueue, ShouldBeUnique
     /**
      * Create a new job instance.
      */
-    public function __construct(int $schoolTermId, array $roomIds)
+    public function __construct(int $schoolTermId, array $roomIds, array $solverConfig = [])
     {
         $this->schoolTermId = $schoolTermId;
         $this->roomIds = $roomIds;
+        $this->solverConfig = $solverConfig;
     }
 
     /**
@@ -51,7 +53,7 @@ class ProcessRoomDistribution implements ShouldQueue, ShouldBeUnique
     {
         $term = SchoolTerm::findOrFail($this->schoolTermId);
 
-        $payload = (new RoomAllocationPayloadBuilder())->build($term, $this->roomIds);
+        $payload = (new RoomAllocationPayloadBuilder())->build($term, $this->roomIds, $this->solverConfig);
 
         $solverUrl = rtrim(config('alocacao.solver.url'), '/');
         $apiToken = config('alocacao.solver.api_token');

--- a/app/Services/HistoricalEnrollmentService.php
+++ b/app/Services/HistoricalEnrollmentService.php
@@ -49,6 +49,11 @@ class HistoricalEnrollmentService
     private int $cap = 100;
 
     /**
+     * Número de anos anteriores a consultar no cálculo da média histórica.
+     */
+    private int $yearsToLookBack = 5;
+
+    /**
      * Palavras-chave em obstur que indicam turmas especiais e devem ser excluídas.
      */
     private array $exclusionObsturKeywords = [
@@ -61,13 +66,20 @@ class HistoricalEnrollmentService
         'divididas',
     ];
 
-    public function __construct()
+    public function __construct(array $configOverrides = [])
     {
-        $this->thresholdPercent = (float) config('alocacao.historical_threshold_percent', 7.0);
-        $this->minHistoricalYears = (int) config('alocacao.historical_min_years', 2);
-        $this->estimationMethod = (string) config('alocacao.historical_estimation_method', 'average_plus_stddev');
-        $this->stddevMultiplier = (float) config('alocacao.historical_stddev_multiplier', 3.0);
-        $this->cap = (int) config('alocacao.historical_cap', 100);
+        $this->thresholdPercent = (float) ($configOverrides['historical_threshold_percent']
+            ?? config('alocacao.historical_threshold_percent', 7.0));
+        $this->minHistoricalYears = (int) ($configOverrides['historical_min_years']
+            ?? config('alocacao.historical_min_years', 2));
+        $this->estimationMethod = (string) ($configOverrides['historical_estimation_method']
+            ?? config('alocacao.historical_estimation_method', 'average_plus_stddev'));
+        $this->stddevMultiplier = (float) ($configOverrides['historical_stddev_multiplier']
+            ?? config('alocacao.historical_stddev_multiplier', 3.0));
+        $this->cap = (int) ($configOverrides['historical_cap']
+            ?? config('alocacao.historical_cap', 100));
+        $this->yearsToLookBack = (int) ($configOverrides['historical_lookback_years']
+            ?? config('alocacao.historical_lookback_years', 5));
     }
 
     /**
@@ -441,9 +453,8 @@ class HistoricalEnrollmentService
     private function fetchHistoricalEnrollments(string $coddis, string $codturSuffix, int $currentYear): array
     {
         $results = [];
-        $yearsToLookBack = (int) config('alocacao.historical_lookback_years', 5);
 
-        for ($offset = 1; $offset <= $yearsToLookBack; $offset++) {
+        for ($offset = 1; $offset <= $this->yearsToLookBack; $offset++) {
             $year = $currentYear - $offset;
             $codtur = $year . '1' . $codturSuffix;
 

--- a/app/Services/RoomAllocationPayloadBuilder.php
+++ b/app/Services/RoomAllocationPayloadBuilder.php
@@ -11,9 +11,11 @@ use Illuminate\Support\Collection;
 class RoomAllocationPayloadBuilder
 {
     private HistoricalEnrollmentService $historicalService;
+    private bool $usesInjectedHistoricalService;
 
     public function __construct(?HistoricalEnrollmentService $historicalService = null)
     {
+        $this->usesInjectedHistoricalService = $historicalService !== null;
         $this->historicalService = $historicalService ?? app(HistoricalEnrollmentService::class);
     }
 
@@ -36,6 +38,19 @@ class RoomAllocationPayloadBuilder
     public function build(SchoolTerm $schoolTerm, array $roomIds, array $overrides = []): array
     {
         $roomIds = array_map('intval', $roomIds);
+
+        if (! $this->usesInjectedHistoricalService) {
+            $historicalOverrides = array_filter([
+                'historical_estimation_method' => $overrides['historical_estimation_method'] ?? null,
+                'historical_threshold_percent' => isset($overrides['historical_threshold_percent']) ? (float) $overrides['historical_threshold_percent'] : null,
+                'historical_lookback_years' => isset($overrides['historical_lookback_years']) ? (int) $overrides['historical_lookback_years'] : null,
+                'historical_min_years' => isset($overrides['historical_min_years']) ? (int) $overrides['historical_min_years'] : null,
+                'historical_cap' => isset($overrides['historical_cap']) ? (int) $overrides['historical_cap'] : null,
+                'historical_stddev_multiplier' => isset($overrides['historical_stddev_multiplier']) ? (float) $overrides['historical_stddev_multiplier'] : null,
+            ], fn ($value) => $value !== null);
+
+            $this->historicalService = new HistoricalEnrollmentService($historicalOverrides);
+        }
 
         $allClasses = SchoolClass::whereBelongsTo($schoolTerm)
             ->with(['classschedules', 'fusion.master', 'fusion.master.room', 'courseinformations', 'room'])
@@ -417,6 +432,7 @@ class RoomAllocationPayloadBuilder
     private function buildConfig(array $overrides): array
     {
         $defaults = config('alocacao.room_allocation', []);
+
         return array_merge($defaults, $overrides);
     }
 

--- a/resources/views/rooms/index.blade.php
+++ b/resources/views/rooms/index.blade.php
@@ -290,84 +290,108 @@ $tooltips = [
 <div class="modal fade" id="solverConfigModal" tabindex="-1" role="dialog" aria-labelledby="solverConfigModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="solverConfigModalLabel">Configuração do Solver</h5>
+            <div class="modal-header bg-light">
+                <h5 class="modal-title font-weight-bold" id="solverConfigModalLabel">Configuração do Solver</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Fechar">
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
             <div class="modal-body">
-                <ul class="nav nav-tabs" id="solverConfigTabs" role="tablist">
+                <p class="text-muted small mb-3">
+                    Ajuste os parâmetros abaixo para esta execução do solver. Os valores não serão salvos no servidor.
+                </p>
+
+                <ul class="nav nav-tabs nav-fill" id="solverConfigTabs" role="tablist">
                     <li class="nav-item">
-                        <a class="nav-link active" id="tab-hard-link" data-toggle="tab" href="#tab-hard" role="tab">Hard Constraints</a>
+                        <a class="nav-link active font-weight-bold" id="tab-hard-link" data-toggle="tab" href="#tab-hard" role="tab">Hard Constraints</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" id="tab-soft-link" data-toggle="tab" href="#tab-soft" role="tab">Soft Constraints</a>
+                        <a class="nav-link font-weight-bold" id="tab-soft-link" data-toggle="tab" href="#tab-soft" role="tab">Soft Constraints</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" id="tab-estimativa-link" data-toggle="tab" href="#tab-estimativa" role="tab">Estimativa 1º Sem</a>
+                        <a class="nav-link font-weight-bold" id="tab-estimativa-link" data-toggle="tab" href="#tab-estimativa" role="tab">Estimativa 1º Sem</a>
                     </li>
                 </ul>
 
-                <div class="tab-content mt-3">
+                <div class="tab-content p-3 border border-top-0 rounded-bottom">
                     <!-- Aba 1 - Hard Constraints -->
                     <div class="tab-pane fade show active" id="tab-hard" role="tabpanel">
-                        @foreach ([
-                            'strict_capacity' => 'Capacidade Estrita',
-                            'block_b_restriction_for_pos' => 'Restrição Bloco B p/ Pós',
-                            'block_a_restriction_for_freshmen' => 'Restrição Bloco A p/ Calouros',
-                        ] as $key => $label)
-                            <div class="form-group">
-                                <label data-toggle="tooltip" data-placement="top" title="{{ $tooltips[$key] }}">{{ $label }}</label>
-                                <select name="solver_config[{{ $key }}]" class="form-control" form="distributesForm">
-                                    <option value="1" {{ config('alocacao.room_allocation.' . $key) ? 'selected' : '' }}>Sim</option>
-                                    <option value="0" {{ ! config('alocacao.room_allocation.' . $key) ? 'selected' : '' }}>Não</option>
-                                </select>
-                            </div>
-                        @endforeach
+                        <div class="row">
+                            @foreach ([
+                                'strict_capacity' => 'Capacidade Estrita',
+                                'block_b_restriction_for_pos' => 'Restrição Bloco B p/ Pós',
+                                'block_a_restriction_for_freshmen' => 'Restrição Bloco A p/ Calouros',
+                            ] as $key => $label)
+                                <div class="col-md-4">
+                                    <div class="form-group">
+                                        <div class="custom-control custom-switch">
+                                            <input type="hidden" name="solver_config[{{ $key }}]" value="0" form="distributesForm">
+                                            <input type="checkbox" class="custom-control-input" id="solver_config_{{ $key }}"
+                                                name="solver_config[{{ $key }}]" value="1"
+                                                form="distributesForm"
+                                                {{ config('alocacao.room_allocation.' . $key) ? 'checked' : '' }}>
+                                            <label class="custom-control-label" for="solver_config_{{ $key }}"
+                                                data-toggle="tooltip" data-placement="top" title="{{ $tooltips[$key] }}">
+                                                {{ $label }}
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
                     </div>
 
                     <!-- Aba 2 - Soft Constraints -->
                     <div class="tab-pane fade" id="tab-soft" role="tabpanel">
-                        @foreach ([
-                            'undergrad_in_block_a_penalty' => 'Penalidade Graduação Bloco A',
-                            'pos_in_block_b_penalty' => 'Penalidade Pós Bloco B',
-                            'wasted_seats_weight' => 'Peso Assentos Ociosos',
-                            'unassigned_penalty' => 'Penalidade Turma sem Sala',
-                            'priority_weight' => 'Peso de Prioridade',
-                        ] as $key => $label)
-                            <div class="form-group">
-                                <label data-toggle="tooltip" data-placement="top" title="{{ $tooltips[$key] }}">{{ $label }}</label>
-                                <input type="number" step="any" class="form-control" name="solver_config[{{ $key }}]" value="{{ config('alocacao.room_allocation.' . $key) }}" form="distributesForm">
-                            </div>
-                        @endforeach
+                        <div class="row">
+                            @foreach ([
+                                'undergrad_in_block_a_penalty' => 'Penalidade Graduação Bloco A',
+                                'pos_in_block_b_penalty' => 'Penalidade Pós Bloco B',
+                                'wasted_seats_weight' => 'Peso Assentos Ociosos',
+                                'unassigned_penalty' => 'Penalidade Turma sem Sala',
+                                'priority_weight' => 'Peso de Prioridade',
+                            ] as $key => $label)
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label class="font-weight-bold" data-toggle="tooltip" data-placement="top" title="{{ $tooltips[$key] }}">{{ $label }}</label>
+                                        <input type="number" step="any" class="form-control" name="solver_config[{{ $key }}]" value="{{ config('alocacao.room_allocation.' . $key) }}" form="distributesForm">
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
                     </div>
 
                     <!-- Aba 3 - Estimativa 1º Sem -->
                     <div class="tab-pane fade" id="tab-estimativa" role="tabpanel">
-                        <div class="form-group">
-                            <label data-toggle="tooltip" data-placement="top" title="{{ $tooltips['historical_estimation_method'] }}">Método</label>
-                            <select name="solver_config[historical_estimation_method]" class="form-control" form="distributesForm">
-                                <option value="average_plus_stddev" {{ config('alocacao.historical_estimation_method') === 'average_plus_stddev' ? 'selected' : '' }}>average_plus_stddev</option>
-                                <option value="none" {{ config('alocacao.historical_estimation_method') === 'none' ? 'selected' : '' }}>none</option>
-                            </select>
-                        </div>
-                        @foreach ([
-                            'historical_threshold_percent' => 'Threshold %',
-                            'historical_lookback_years' => 'Anos de Lookback',
-                            'historical_min_years' => 'Mínimo de Anos',
-                            'historical_cap' => 'Limite/Cap',
-                            'historical_stddev_multiplier' => 'Multiplicador DP',
-                        ] as $key => $label)
-                            <div class="form-group">
-                                <label data-toggle="tooltip" data-placement="top" title="{{ $tooltips[$key] }}">{{ $label }}</label>
-                                <input type="number" step="any" class="form-control" name="solver_config[{{ $key }}]" value="{{ config('alocacao.' . $key) }}" form="distributesForm">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="form-group">
+                                    <label class="font-weight-bold" data-toggle="tooltip" data-placement="top" title="{{ $tooltips['historical_estimation_method'] }}">Método</label>
+                                    <select name="solver_config[historical_estimation_method]" class="form-control" form="distributesForm">
+                                        <option value="average_plus_stddev" {{ config('alocacao.historical_estimation_method') === 'average_plus_stddev' ? 'selected' : '' }}>average_plus_stddev</option>
+                                        <option value="none" {{ config('alocacao.historical_estimation_method') === 'none' ? 'selected' : '' }}>none</option>
+                                    </select>
+                                </div>
                             </div>
-                        @endforeach
+                            @foreach ([
+                                'historical_threshold_percent' => 'Threshold %',
+                                'historical_lookback_years' => 'Anos de Lookback',
+                                'historical_min_years' => 'Mínimo de Anos',
+                                'historical_cap' => 'Limite/Cap',
+                                'historical_stddev_multiplier' => 'Multiplicador DP',
+                            ] as $key => $label)
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label class="font-weight-bold" data-toggle="tooltip" data-placement="top" title="{{ $tooltips[$key] }}">{{ $label }}</label>
+                                        <input type="number" step="any" class="form-control" name="solver_config[{{ $key }}]" value="{{ config('alocacao.' . $key) }}" form="distributesForm">
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
                     </div>
                 </div>
             </div>
-            <div class="modal-footer">
+            <div class="modal-footer bg-light">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
                 <button type="submit" form="distributesForm" class="btn btn-primary"
                     onclick="return confirm('Você tem certeza? Redistribuir as turmas irá desfazer a distribuição atual!')">

--- a/resources/views/rooms/index.blade.php
+++ b/resources/views/rooms/index.blade.php
@@ -30,18 +30,20 @@
                             </form>
                             -->
                             
-                            <form id="distributesForm" style="display: inline;"action="{{ route('rooms.distributes') }}" method="POST"
+                            <button class="btn btn-outline-primary"
+                                id="btn-distributes"
+                                type="button"
+                                data-toggle="modal"
+                                data-target="#solverConfigModal"
+                            >
+                                Distribuir Turmas
+                            </button>
+
+                            <form id="distributesForm" style="display: none;" action="{{ route('rooms.distributes') }}" method="POST"
                             enctype="multipart/form-data"
                             >
                                 @method('patch')
                                 @csrf
-                                <button  class="btn btn-outline-primary"
-                                    id="btn-distributes"
-                                    type="submit"
-                                    onclick="return confirm('Você tem certeza? Redistribuir as turmas irá desfazer a distribuição atual!')" 
-                                >
-                                    Distribuir Turmas
-                                </button>
                             </form>
 
                             <form id="emptyForm" style="display: inline;" action="{{ route('rooms.empty') }}" method="POST"
@@ -260,6 +262,117 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Fechar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@php
+$tooltips = [
+    'strict_capacity' => 'Quando ativada, o solver não pode alocar turmas em salas com capacidade menor que a demanda.',
+    'block_b_restriction_for_pos' => 'Quando ativada, pós-graduação não pode ser alocada no Bloco B.',
+    'block_a_restriction_for_freshmen' => 'Quando ativada, calouros do IME devem ser alocados no Bloco A.',
+    'undergrad_in_block_a_penalty' => 'Penalidade aplicada ao alocar graduação no Bloco A (deveria ser preferencialmente no Bloco B).',
+    'pos_in_block_b_penalty' => 'Penalidade aplicada ao alocar pós-graduação no Bloco B (deveria ser preferencialmente no Bloco A).',
+    'wasted_seats_weight' => 'Peso dado ao número de assentos ociosos nas salas alocadas.',
+    'unassigned_penalty' => 'Penalidade por cada turma que ficar sem sala na solução.',
+    'priority_weight' => 'Peso dado às prioridades explícitas de sala/turma.',
+    'historical_estimation_method' => 'Método usado para estimar demanda a partir do histórico de matriculados.',
+    'historical_threshold_percent' => 'Diferença percentual mínima entre inscritos atuais e média histórica para ativar a correção.',
+    'historical_lookback_years' => 'Quantidade de anos anteriores consultados no cálculo da média histórica.',
+    'historical_min_years' => 'Número mínimo de anos históricos com dados para considerar a estimativa confiável.',
+    'historical_cap' => 'Teto máximo para a demanda estimada.',
+    'historical_stddev_multiplier' => 'Multiplicador do desvio padrão somado à média no método average_plus_stddev.',
+];
+@endphp
+
+<!-- Modal de Configuração do Solver -->
+<div class="modal fade" id="solverConfigModal" tabindex="-1" role="dialog" aria-labelledby="solverConfigModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="solverConfigModalLabel">Configuração do Solver</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Fechar">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <ul class="nav nav-tabs" id="solverConfigTabs" role="tablist">
+                    <li class="nav-item">
+                        <a class="nav-link active" id="tab-hard-link" data-toggle="tab" href="#tab-hard" role="tab">Hard Constraints</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="tab-soft-link" data-toggle="tab" href="#tab-soft" role="tab">Soft Constraints</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="tab-estimativa-link" data-toggle="tab" href="#tab-estimativa" role="tab">Estimativa 1º Sem</a>
+                    </li>
+                </ul>
+
+                <div class="tab-content mt-3">
+                    <!-- Aba 1 - Hard Constraints -->
+                    <div class="tab-pane fade show active" id="tab-hard" role="tabpanel">
+                        @foreach ([
+                            'strict_capacity' => 'Capacidade Estrita',
+                            'block_b_restriction_for_pos' => 'Restrição Bloco B p/ Pós',
+                            'block_a_restriction_for_freshmen' => 'Restrição Bloco A p/ Calouros',
+                        ] as $key => $label)
+                            <div class="form-group">
+                                <label data-toggle="tooltip" data-placement="top" title="{{ $tooltips[$key] }}">{{ $label }}</label>
+                                <select name="solver_config[{{ $key }}]" class="form-control" form="distributesForm">
+                                    <option value="1" {{ config('alocacao.room_allocation.' . $key) ? 'selected' : '' }}>Sim</option>
+                                    <option value="0" {{ ! config('alocacao.room_allocation.' . $key) ? 'selected' : '' }}>Não</option>
+                                </select>
+                            </div>
+                        @endforeach
+                    </div>
+
+                    <!-- Aba 2 - Soft Constraints -->
+                    <div class="tab-pane fade" id="tab-soft" role="tabpanel">
+                        @foreach ([
+                            'undergrad_in_block_a_penalty' => 'Penalidade Graduação Bloco A',
+                            'pos_in_block_b_penalty' => 'Penalidade Pós Bloco B',
+                            'wasted_seats_weight' => 'Peso Assentos Ociosos',
+                            'unassigned_penalty' => 'Penalidade Turma sem Sala',
+                            'priority_weight' => 'Peso de Prioridade',
+                        ] as $key => $label)
+                            <div class="form-group">
+                                <label data-toggle="tooltip" data-placement="top" title="{{ $tooltips[$key] }}">{{ $label }}</label>
+                                <input type="number" step="any" class="form-control" name="solver_config[{{ $key }}]" value="{{ config('alocacao.room_allocation.' . $key) }}" form="distributesForm">
+                            </div>
+                        @endforeach
+                    </div>
+
+                    <!-- Aba 3 - Estimativa 1º Sem -->
+                    <div class="tab-pane fade" id="tab-estimativa" role="tabpanel">
+                        <div class="form-group">
+                            <label data-toggle="tooltip" data-placement="top" title="{{ $tooltips['historical_estimation_method'] }}">Método</label>
+                            <select name="solver_config[historical_estimation_method]" class="form-control" form="distributesForm">
+                                <option value="average_plus_stddev" {{ config('alocacao.historical_estimation_method') === 'average_plus_stddev' ? 'selected' : '' }}>average_plus_stddev</option>
+                                <option value="none" {{ config('alocacao.historical_estimation_method') === 'none' ? 'selected' : '' }}>none</option>
+                            </select>
+                        </div>
+                        @foreach ([
+                            'historical_threshold_percent' => 'Threshold %',
+                            'historical_lookback_years' => 'Anos de Lookback',
+                            'historical_min_years' => 'Mínimo de Anos',
+                            'historical_cap' => 'Limite/Cap',
+                            'historical_stddev_multiplier' => 'Multiplicador DP',
+                        ] as $key => $label)
+                            <div class="form-group">
+                                <label data-toggle="tooltip" data-placement="top" title="{{ $tooltips[$key] }}">{{ $label }}</label>
+                                <input type="number" step="any" class="form-control" name="solver_config[{{ $key }}]" value="{{ config('alocacao.' . $key) }}" form="distributesForm">
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
+                <button type="submit" form="distributesForm" class="btn btn-primary"
+                    onclick="return confirm('Você tem certeza? Redistribuir as turmas irá desfazer a distribuição atual!')">
+                    Executar Solver
+                </button>
             </div>
         </div>
     </div>
@@ -510,6 +623,12 @@ $( function() {
 
     $('#allocationStatesModal').on('shown.bs.modal', function () {
         loadAllocationStates();
+    });
+
+    $('#solverConfigModal').on('shown.bs.modal', function () {
+        $(this).find('[data-toggle="tooltip"]').tooltip();
+    }).on('hidden.bs.modal', function () {
+        $(this).find('[data-toggle="tooltip"]').tooltip('dispose');
     });
 });
 </script>

--- a/tests/Feature/DistributionFlowTest.php
+++ b/tests/Feature/DistributionFlowTest.php
@@ -63,6 +63,69 @@ class DistributionFlowTest extends TestCase
     }
 
     /** @test */
+    public function operator_can_dispatch_distribution_with_solver_config_overrides()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+            'externa' => false,
+        ]);
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        Http::fake([
+            'http://solver.test/api/v1/solve' => Http::response([
+                'job_id' => 'flow-config-123',
+            ], 202),
+        ]);
+
+        $response = $this->actingAsOperator()
+            ->patch('/rooms/distributes', [
+                'rooms_id' => [$room->id],
+                'solver_config' => [
+                    'strict_capacity' => false,
+                    'unassigned_penalty' => 2000.0,
+                    'historical_estimation_method' => 'none',
+                ],
+            ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('alert-info');
+
+        $cached = Cache::get("allocation:{$term->id}");
+        $this->assertNotNull($cached);
+        $this->assertEquals('flow-config-123', $cached['job_id']);
+
+        $solverLog = \App\Models\SolverLog::where('job_id', 'flow-config-123')->first();
+        $this->assertNotNull($solverLog);
+        $this->assertFalse($solverLog->payload['config']['strict_capacity']);
+        $this->assertEquals(2000.0, $solverLog->payload['config']['unassigned_penalty']);
+        $this->assertEquals('none', $solverLog->payload['config']['historical_estimation_method']);
+    }
+
+    /** @test */
+    public function distributes_request_rejects_invalid_solver_config()
+    {
+        $room = Room::factory()->create();
+
+        $response = $this->actingAsOperator()
+            ->patch('/rooms/distributes', [
+                'rooms_id' => [$room->id],
+                'solver_config' => [
+                    'historical_estimation_method' => 'invalid_method',
+                    'historical_lookback_years' => -1,
+                ],
+            ]);
+
+        $response->assertSessionHasErrors([
+            'solver_config.historical_estimation_method',
+            'solver_config.historical_lookback_years',
+        ]);
+    }
+
+    /** @test */
     public function double_dispatch_is_prevented()
     {
         $term = SchoolTerm::factory()->create();
@@ -243,5 +306,72 @@ class DistributionFlowTest extends TestCase
 
         $response->assertRedirect();
         $response->assertSessionHas('alert-warning');
+    }
+
+    /** @test */
+    public function result_webhook_generates_comparison_message()
+    {
+        $term = SchoolTerm::factory()->create();
+        $roomA = Room::factory()->create();
+        $roomB = Room::factory()->create();
+
+        $classNew = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+            'externa' => false,
+        ]);
+        $classChanged = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $roomA->id,
+            'externa' => false,
+        ]);
+        $classUnchanged = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => $roomA->id,
+            'externa' => false,
+        ]);
+
+        $solverLog = \App\Models\SolverLog::factory()->create([
+            'school_term_id' => $term->id,
+            'job_id' => 'compare-123',
+            'status' => 'solving',
+        ]);
+
+        \App\Models\AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Pré-Solver',
+            'solver_log_id' => $solverLog->id,
+            'allocations' => [
+                $classNew->id => null,
+                $classChanged->id => $roomA->id,
+                $classUnchanged->id => $roomA->id,
+            ],
+        ]);
+
+        Cache::put("allocation:{$term->id}", [
+            'job_id' => 'compare-123',
+            'status' => 'solving',
+            'progress' => 50,
+        ], now()->addHour());
+
+        Cache::put("allocation:job:compare-123", $term->id, now()->addHour());
+
+        $response = $this->postJson('/api/webhooks/allocation-result', [
+            'job_id' => 'compare-123',
+            'status' => 'optimal',
+            'allocations' => [
+                ['group_id' => $classNew->id, 'room_id' => $roomB->id],
+                ['group_id' => $classChanged->id, 'room_id' => $roomB->id],
+                ['group_id' => $classUnchanged->id, 'room_id' => $roomA->id],
+            ],
+            'unassigned_groups' => [],
+            'suggestions' => [],
+        ]);
+
+        $response->assertOk();
+
+        $cached = Cache::get("allocation:{$term->id}");
+        $this->assertStringContainsString('1 turma(s) nova(s) foi(ram) alocada(s)', $cached['message']);
+        $this->assertStringContainsString('1 turma(s) mudou(aram) de sala', $cached['message']);
     }
 }

--- a/tests/Unit/HistoricalEnrollmentServiceTest.php
+++ b/tests/Unit/HistoricalEnrollmentServiceTest.php
@@ -401,4 +401,60 @@ class HistoricalEnrollmentServiceTest extends TestCase
         $this->assertTrue($result['applied']);
         $this->assertEquals(50, $result['demand']); // 50 + 3*0
     }
+
+    /** @test */
+    public function it_accepts_config_overrides_in_constructor()
+    {
+        config(['alocacao.historical_threshold_percent' => 7.0]);
+        config(['alocacao.historical_cap' => 100]);
+        config(['alocacao.historical_lookback_years' => 5]);
+
+        $service = new HistoricalEnrollmentService([
+            'historical_threshold_percent' => 15.0,
+            'historical_cap' => 80,
+            'historical_lookback_years' => 3,
+        ]);
+
+        $reflection = new \ReflectionClass($service);
+
+        $thresholdProperty = $reflection->getProperty('thresholdPercent');
+        $thresholdProperty->setAccessible(true);
+        $threshold = $thresholdProperty->getValue($service);
+
+        $capProperty = $reflection->getProperty('cap');
+        $capProperty->setAccessible(true);
+        $cap = $capProperty->getValue($service);
+
+        $lookbackProperty = $reflection->getProperty('yearsToLookBack');
+        $lookbackProperty->setAccessible(true);
+        $lookback = $lookbackProperty->getValue($service);
+
+        $this->assertEquals(15.0, $threshold);
+        $this->assertEquals(80, $cap);
+        $this->assertEquals(3, $lookback);
+    }
+
+    /** @test */
+    public function it_falls_back_to_config_when_overrides_are_missing()
+    {
+        config(['alocacao.historical_threshold_percent' => 12.0]);
+        config(['alocacao.historical_cap' => 120]);
+
+        $service = new HistoricalEnrollmentService([
+            'historical_cap' => 90,
+        ]);
+
+        $reflection = new \ReflectionClass($service);
+
+        $thresholdProperty = $reflection->getProperty('thresholdPercent');
+        $thresholdProperty->setAccessible(true);
+        $threshold = $thresholdProperty->getValue($service);
+
+        $capProperty = $reflection->getProperty('cap');
+        $capProperty->setAccessible(true);
+        $cap = $capProperty->getValue($service);
+
+        $this->assertEquals(12.0, $threshold);
+        $this->assertEquals(90, $cap);
+    }
 }

--- a/tests/Unit/RoomAllocationPayloadBuilderTest.php
+++ b/tests/Unit/RoomAllocationPayloadBuilderTest.php
@@ -1221,4 +1221,34 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $class->refresh();
         $this->assertEquals(10, $class->estmtr);
     }
+
+    /** @test */
+    public function it_applies_solver_config_overrides_to_payload_config()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'estmtr' => 30,
+            'externa' => false,
+            'fusion_id' => null,
+        ]);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        $overrides = [
+            'strict_capacity' => false,
+            'undergrad_in_block_a_penalty' => 999.0,
+            'historical_estimation_method' => 'none',
+        ];
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id], $overrides);
+
+        $this->assertFalse($payload['config']['strict_capacity']);
+        $this->assertEquals(999.0, $payload['config']['undergrad_in_block_a_penalty']);
+        $this->assertEquals('none', $payload['config']['historical_estimation_method']);
+    }
 }


### PR DESCRIPTION
## Summary

This PR implements the solver configuration modal and post-solver comparison described in #62.

## Changes

- **Frontend (`rooms/index`)**: the "Distribuir Turmas" button now opens a Bootstrap modal with three tabs:
  - Hard Constraints
  - Soft Constraints (weights)
  - Estimativa 1º Semestre
  All fields are populated from `config('alocacao')` on every open and include tooltips.
- **Request validation**: `DistributesRoomRequest` validates the optional `solver_config` array.
- **Controller / Job**: `RoomController@distributes` and `ProcessRoomDistribution` now propagate the transient config overrides to the payload builder.
- **Payload builder**: `RoomAllocationPayloadBuilder` applies overrides to the `config` block and passes historical-estimation overrides to `HistoricalEnrollmentService`.
- **Historical service**: refactored constructor to accept `array $configOverrides = []` while keeping config fallbacks. No DB writes happen in the solver flow.
- **Webhook comparison**: `AllocationResultWebhookController` compares the final allocation against the auto-saved "Pré-Solver" `AllocationState` and writes a rich message to the cache, e.g.:
  > "Distribuição concluída: X turmas novas foram alocadas, Y turmas mudaram de sala."
- **Tests**: added coverage for config propagation, request validation, constructor overrides, and the comparison message.

## Acceptance Criteria

- [x] "Distribuir Turmas" opens the configuration modal
- [x] Modal fields default to `config('alocacao')` and do not persist in the browser
- [x] All three tabs with tooltips are present
- [x] Overrides are transient (no DB or `.env` changes)
- [x] Historical estimation only affects payload demand, not persisted columns
- [x] Post-solver comparison message is shown via the existing progress UI

## Testing

```bash
php vendor/bin/phpunit tests/Feature/DistributionFlowTest.php
php vendor/bin/phpunit tests/Unit/RoomAllocationPayloadBuilderTest.php
php vendor/bin/phpunit tests/Unit/HistoricalEnrollmentServiceTest.php
```

> Note: `MigrateReservationsToSalasCommandTest` failures are pre-existing on `master` due to missing Salas API credentials in the test environment.

Closes #62
