### PR TITLE
Processar Sugestões de Quebra e Renderizar na UI

### DIFF
--- a/app/Http/Controllers/AllocationResultWebhookController.php
+++ b/app/Http/Controllers/AllocationResultWebhookController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\AllocationState;
+use App\Models\ClassSchedule;
+use App\Models\Room;
 use App\Models\SchoolClass;
 use App\Models\SchoolTerm;
 use App\Models\SolverLog;
@@ -31,6 +33,9 @@ class AllocationResultWebhookController extends Controller
             'unassigned_groups' => 'nullable|array',
             'unassigned_groups.*' => 'integer',
             'suggestions' => 'nullable|array',
+            'suggestions.*.group_id' => 'required_with:suggestions|integer',
+            'suggestions.*.timeslot_id' => 'required_with:suggestions|integer',
+            'suggestions.*.suggested_room_id' => 'required_with:suggestions|integer',
             'metrics' => 'nullable|array',
         ]);
 
@@ -129,11 +134,14 @@ class AllocationResultWebhookController extends Controller
             return response()->json(['message' => 'Failed to apply results'], 500);
         }
 
-        // Store suggestions (Pass 2) for potential manual review
+        // Store suggestions (real split-class hints) for manual review
         if (! empty($suggestions)) {
             Cache::put(
                 "allocation_suggestions:{$schoolTermId}",
-                $suggestions,
+                [
+                    'raw' => $suggestions,
+                    'formatted' => $this->formatSuggestionsForDisplay($suggestions, $jobId),
+                ],
                 now()->addDays(7)
             );
         }
@@ -224,6 +232,124 @@ class AllocationResultWebhookController extends Controller
         }
 
         return 'Distribuição concluída: ' . implode(', ', $parts) . '.';
+    }
+
+    /**
+     * Enrich raw solver suggestions with human-readable day and room names,
+     * grouped by school class for display in the UI.
+     *
+     * The solver returns timeslot_id as the index inside the payload timeslots
+     * array. We map it back to the local class_schedules record using the
+     * dispatched payload stored in SolverLog.
+     */
+    private function formatSuggestionsForDisplay(array $suggestions, string $jobId): array
+    {
+        if (empty($suggestions)) {
+            return [];
+        }
+
+        $timeslotMap = $this->buildTimeslotToScheduleMap($suggestions, $jobId);
+
+        $groupIds = array_values(array_unique(array_column($suggestions, 'group_id')));
+        $roomIds = array_values(array_unique(array_column($suggestions, 'suggested_room_id')));
+
+        $classes = SchoolClass::whereIn('id', $groupIds)
+            ->get()
+            ->keyBy('id');
+
+        $rooms = Room::whereIn('id', $roomIds)
+            ->get()
+            ->keyBy('id');
+
+        $scheduleIds = array_values(array_filter($timeslotMap));
+        $schedules = ClassSchedule::whereIn('id', $scheduleIds)
+            ->get()
+            ->keyBy('id');
+
+        $grouped = [];
+        foreach ($suggestions as $suggestion) {
+            $class = $classes[$suggestion['group_id']] ?? null;
+            $room = $rooms[$suggestion['suggested_room_id']] ?? null;
+            $scheduleId = $timeslotMap[$suggestion['timeslot_id']] ?? null;
+            $schedule = $scheduleId ? ($schedules[$scheduleId] ?? null) : null;
+
+            if (! $class || ! $room || ! $schedule) {
+                continue;
+            }
+
+            $groupId = $class->id;
+            if (! isset($grouped[$groupId])) {
+                $classLabel = $class->tiptur === 'Graduação'
+                    ? 'T.'.substr($class->codtur, -2)
+                    : $class->codtur;
+                $grouped[$groupId] = [
+                    'label' => "Turma {$classLabel}",
+                    'days' => [],
+                ];
+            }
+
+            $day = ucfirst($schedule->diasmnocp);
+            $grouped[$groupId]['days'][$day] = $room->nome;
+        }
+
+        $formatted = [];
+        foreach ($grouped as $group) {
+            $parts = [];
+            foreach ($group['days'] as $day => $roomName) {
+                $parts[] = "{$day}: {$roomName}";
+            }
+            $formatted[] = $group['label'] . ' - ' . implode(', ', $parts);
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * Map solver timeslot indices back to local class_schedule IDs using the
+     * payload stored when the job was dispatched.
+     */
+    private function buildTimeslotToScheduleMap(array $suggestions, string $jobId): array
+    {
+        $timeslotIds = array_values(array_unique(array_column($suggestions, 'timeslot_id')));
+
+        $solverLog = SolverLog::where('job_id', $jobId)->first();
+        $payload = $solverLog ? ($solverLog->payload ?? []) : [];
+        $timeslots = $payload['timeslots'] ?? [];
+
+        $map = [];
+        foreach ($timeslotIds as $timeslotId) {
+            $timeslot = collect($timeslots)->firstWhere('id', $timeslotId);
+            if (! $timeslot || empty($timeslot['label'])) {
+                continue;
+            }
+
+            $schedule = $this->findScheduleByTimeslotLabel($timeslot['label']);
+            if ($schedule) {
+                $map[$timeslotId] = $schedule->id;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Find a class schedule record that matches a payload timeslot label.
+     */
+    private function findScheduleByTimeslotLabel(string $label): ?ClassSchedule
+    {
+        $parts = explode('_', $label);
+        if (count($parts) !== 3) {
+            return null;
+        }
+
+        [$day, $startRaw, $endRaw] = $parts;
+        $start = substr($startRaw, 0, 2) . ':' . substr($startRaw, 2, 2);
+        $end = substr($endRaw, 0, 2) . ':' . substr($endRaw, 2, 2);
+
+        return ClassSchedule::where('diasmnocp', $day)
+            ->where('horent', $start)
+            ->where('horsai', $end)
+            ->first();
     }
 
     /**

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -48,7 +48,15 @@ class RoomController extends Controller
 
         $salas = Room::all();
 
-        return view('rooms.index', compact(['salas']));
+        $schoolTerm = SchoolTerm::getLatest();
+        $suggestions = $schoolTerm
+            ? Cache::get("allocation_suggestions:{$schoolTerm->id}")
+            : null;
+        $formattedSuggestions = is_array($suggestions)
+            ? ($suggestions['formatted'] ?? [])
+            : [];
+
+        return view('rooms.index', compact(['salas', 'formattedSuggestions']));
     }
 
     /**

--- a/resources/views/rooms/index.blade.php
+++ b/resources/views/rooms/index.blade.php
@@ -12,6 +12,18 @@
             <div id="progressbar-div">
             </div>
             <br>
+
+            @if (!empty($formattedSuggestions))
+                <div class="alert alert-info">
+                    <strong>Sugestões de quebra de turmas:</strong>
+                    <ul class="mb-0">
+                        @foreach ($formattedSuggestions as $suggestion)
+                            <li>{{ $suggestion }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
             @if (count($salas) > 0)
                 <div class="d-flex justify-content-center">
                     <div class="col-md-6">

--- a/tests/Feature/AllocationWebhookTest.php
+++ b/tests/Feature/AllocationWebhookTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\ClassSchedule;
 use App\Models\SchoolClass;
 use App\Models\SchoolTerm;
 use App\Models\Room;
@@ -291,6 +292,26 @@ class AllocationWebhookTest extends TestCase
     public function result_webhook_stores_suggestions_in_cache()
     {
         $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create(['nome' => 'B01']);
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+            'tiptur' => 'Graduação',
+            'codtur' => '0123T14',
+        ]);
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+
+        \App\Models\SolverLog::create([
+            'school_term_id' => $term->id,
+            'job_id' => 'job-sugg',
+            'payload' => [
+                'timeslots' => [
+                    ['id' => 0, 'label' => 'seg_0800_1000'],
+                ],
+            ],
+            'status' => 'solving',
+            'dispatched_at' => now(),
+        ]);
 
         Cache::put("allocation:{$term->id}", [
             'job_id' => 'job-sugg',
@@ -298,7 +319,7 @@ class AllocationWebhookTest extends TestCase
         ], now()->addHour());
 
         $suggestions = [
-            ['group_id' => 1, 'suggested_splits' => [['room_id' => 2, 'days' => ['seg']]]],
+            ['group_id' => $class->id, 'timeslot_id' => 0, 'suggested_room_id' => $room->id],
         ];
 
         $response = $this->withWebhookToken()->postJson('/api/webhooks/allocation-result', [
@@ -312,7 +333,8 @@ class AllocationWebhookTest extends TestCase
         $response->assertOk();
 
         $cachedSuggestions = Cache::get("allocation_suggestions:{$term->id}");
-        $this->assertEquals($suggestions, $cachedSuggestions);
+        $this->assertEquals($suggestions, $cachedSuggestions['raw']);
+        $this->assertContains('Turma T.14 - Seg: B01', $cachedSuggestions['formatted']);
     }
 
     /** @test */

--- a/tests/Feature/DistributionFlowTest.php
+++ b/tests/Feature/DistributionFlowTest.php
@@ -572,4 +572,72 @@ class DistributionFlowTest extends TestCase
         $cached = Cache::get("allocation:{$term->id}");
         $this->assertEquals('completed', $cached['status']);
     }
+
+    /** @test */
+    public function result_webhook_marks_split_class_as_unassigned_and_stores_suggestions()
+    {
+        $term = SchoolTerm::factory()->create();
+
+        $roomB01 = Room::factory()->create(['nome' => 'B01']);
+        $roomB02 = Room::factory()->create(['nome' => 'B02']);
+
+        $class = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'room_id' => null,
+            'externa' => false,
+            'tiptur' => 'Graduação',
+            'codtur' => '0123T14',
+            'coddis' => 'MAT9999',
+        ]);
+
+        $scheduleSeg = ClassSchedule::factory()->seg()->morning()->create();
+        $scheduleQua = ClassSchedule::factory()->qua()->morning()->create();
+        $class->classschedules()->attach([$scheduleSeg->id, $scheduleQua->id]);
+
+        \App\Models\SolverLog::create([
+            'school_term_id' => $term->id,
+            'job_id' => 'split-class-123',
+            'payload' => [
+                'timeslots' => [
+                    ['id' => 0, 'label' => 'seg_0800_1000'],
+                    ['id' => 1, 'label' => 'qua_0800_1000'],
+                ],
+            ],
+            'status' => 'solving',
+            'dispatched_at' => now(),
+        ]);
+
+        Cache::put("allocation:{$term->id}", [
+            'job_id' => 'split-class-123',
+            'status' => 'solving',
+        ], now()->addHour());
+
+        Cache::put("allocation:job:split-class-123", $term->id, now()->addHour());
+
+        $response = $this->postJson('/api/webhooks/allocation-result', [
+            'job_id' => 'split-class-123',
+            'status' => 'optimal',
+            'allocations' => [],
+            'unassigned_groups' => [$class->id],
+            'suggestions' => [
+                ['group_id' => $class->id, 'timeslot_id' => 0, 'suggested_room_id' => $roomB01->id],
+                ['group_id' => $class->id, 'timeslot_id' => 1, 'suggested_room_id' => $roomB02->id],
+            ],
+        ]);
+
+        $response->assertOk();
+
+        $this->assertDatabaseHas('school_classes', [
+            'id' => $class->id,
+            'room_id' => null,
+        ]);
+
+        $cachedSuggestions = Cache::get("allocation_suggestions:{$term->id}");
+        $this->assertCount(2, $cachedSuggestions['raw']);
+        $this->assertContains('Turma T.14 - Seg: B01, Qua: B02', $cachedSuggestions['formatted']);
+
+        $cached = Cache::get("allocation:{$term->id}");
+        $this->assertEquals(1, $cached['unassigned_count']);
+        $this->assertEquals(0, $cached['manual_count']);
+    }
 }


### PR DESCRIPTION
## Description

This PR implements the Laravel side of the real split-class workflow introduced by the Python solver (ime-usp-br/alocacao-solver#42).

When the solver cannot allocate a group to a single room, it now returns:
- `unassigned_groups`: the split/missing group IDs (their `room_id` is cleared).
- `suggestions`: an array of `{group_id, timeslot_id, suggested_room_id}` entries, one per broken timeslot.

The Laravel application:
1. Validates the new suggestion contract.
2. Maps solver `timeslot_id` indices back to local `class_schedules` records using the dispatched payload stored in `SolverLog`.
3. Enriches cached suggestions with human-readable labels.
4. Renders them on the rooms index page (e.g., "Turma T.14 - Seg: B01, Qua: B05").

## Related Issue

Closes #68

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Pre-flight Checklist

- [x] Code follows project style guidelines
- [x] Added/updated tests for the new behavior
- [x] All existing tests pass (`./vendor/bin/phpunit`)
- [x] Branch is up-to-date with `master`

## How Has This Been Tested?

- Updated `AllocationWebhookTest::result_webhook_stores_suggestions_in_cache` to the new suggestion contract.
- Added `DistributionFlowTest::result_webhook_marks_split_class_as_unassigned_and_stores_suggestions`, an E2E test that simulates a group with Seg/Qua schedules, empty rooms B01/B02, and verifies the webhook returns the group as unassigned and stores the correct suggestions.
- Full test suite executed inside the Docker container:
  ```
  docker compose exec app ./vendor/bin/phpunit
  OK (190 tests, 588 assertions)
  ```
