### PR TITLE
Remover flag `has_null_enrollment` do Payload do Solver

### DIFF
--- a/app/Services/RoomAllocationPayloadBuilder.php
+++ b/app/Services/RoomAllocationPayloadBuilder.php
@@ -216,18 +216,12 @@ class RoomAllocationPayloadBuilder
         }
 
         $adjustedDemands = [];
-        $hasNull = false;
         $historicalAdjustmentApplied = false;
         $historicalAdjustmentMetadata = [];
 
         foreach ($classes as $class) {
-            if ($class->estmtr === null) {
-                $hasNull = true;
-                continue;
-            }
-
             $adjusted = $this->historicalService->calculateAdjustedDemand($class);
-            $adjustedDemands[] = $adjusted['demand'];
+            $adjustedDemands[] = (int) $adjusted['demand'];
 
             if ($adjusted['applied']) {
                 $historicalAdjustmentApplied = true;
@@ -237,7 +231,7 @@ class RoomAllocationPayloadBuilder
                     'coddis' => $class->coddis,
                     'codtur' => $class->codtur,
                     'estmtr' => $class->estmtr,
-                    'adjusted_demand' => $adjusted['demand'],
+                    'adjusted_demand' => (int) $adjusted['demand'],
                 ], $metadata);
             }
         }
@@ -280,7 +274,6 @@ class RoomAllocationPayloadBuilder
             'nomdis' => $representative->nomdis,
             'tiptur' => $tiptur,
             'demand' => $demand,
-            'has_null_enrollment' => $hasNull,
             'timeslot_labels' => $timeslotLabels,
             'preassigned_room_id' => $preassignedRoomId,
             'same_room_cohort' => $sameRoomCohort,

--- a/tests/Unit/RoomAllocationPayloadBuilderTest.php
+++ b/tests/Unit/RoomAllocationPayloadBuilderTest.php
@@ -52,7 +52,6 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertEquals([$class->id], $group['class_ids']);
         $this->assertEquals('MAC0110', $group['coddis']);
         $this->assertEquals(55, $group['demand']);
-        $this->assertFalse($group['has_null_enrollment']);
         $this->assertCount(1, $group['timeslot_ids']);
         $this->assertEquals(0, $group['timeslot_ids'][0]);
         $this->assertNull($group['preassigned_room_id']);
@@ -130,7 +129,6 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $payload = $builder->build($term, [$room->id]);
 
         $group = $payload['groups'][0];
-        $this->assertTrue($group['has_null_enrollment']);
         $this->assertEquals(40, $group['demand']);
         $this->assertArrayHasKey('same_room_cohort', $group);
         $this->assertNull($group['same_room_cohort']);
@@ -435,7 +433,6 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $payload = $builder->build($term, [$room->id]);
 
         $group = $payload['groups'][0];
-        $this->assertTrue($group['has_null_enrollment']);
         $this->assertEquals(0, $group['demand']);
         $this->assertArrayHasKey('same_room_cohort', $group);
         $this->assertNull($group['same_room_cohort']);


### PR DESCRIPTION
## Summary

Removes the `has_null_enrollment` boolean flag from the solver payload groups and treats `null` enrollment values strictly as `0` in the demand calculation.

## Changes

- `app/Services/RoomAllocationPayloadBuilder.php`
  - Removed `$hasNull` tracking and the `has_null_enrollment` key from group descriptors.
  - Every class is now passed through `calculateAdjustedDemand`; the resulting demand is cast with `(int)` so `null` values are counted as `0` without type errors.
- `tests/Unit/RoomAllocationPayloadBuilderTest.php`
  - Removed assertions that expected `has_null_enrollment`.

## Issue

Closes #75

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / code cleanup
- [ ] Documentation

## Testing

- Ran `vendor/bin/phpunit tests/Unit/RoomAllocationPayloadBuilderTest.php` inside the Docker application container.
- All 42 tests pass; the one unrelated pre-existing config assertion failure (`undergrad_in_block_a_penalty`) is outside the scope of this change.

## Checklist

- [x] Branch created from updated `master`
- [x] Dedicated branch `issue-75` used
- [x] Related unit tests updated
