### PR TITLE
feat(room-allocation): ajustes cirúrgicos de alocação (issue #77)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -277,6 +277,9 @@ HISTORICAL_CAP=100
 # Hard Constraint: protege calouros do IME no Bloco A
 ROOM_ALLOCATION_BLOCK_A_FRESHMEN=true
 
+# Hard Constraint: impede alocação de Pós-Graduação no Bloco B
+ROOM_ALLOCATION_BLOCK_B_POS=false
+
 # Soft Constraint: penalidade ao alocar Graduação no Bloco A
 ROOM_ALLOCATION_UNDERGRAD_BLOCK_A_PENALTY=500.0
 

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -272,7 +272,8 @@ class RoomController extends Controller
         ProcessRoomDistribution::dispatch(
             $schoolterm->id,
             $validated['rooms_id'],
-            $validated['solver_config'] ?? []
+            $validated['solver_config'] ?? [],
+            (bool) ($validated['sync_enrollment'] ?? false)
         );
 
         Session::put("alert-info", "A distribuição de salas foi iniciada. Acompanhe o progresso na barra acima.");

--- a/app/Http/Requests/DistributesRoomRequest.php
+++ b/app/Http/Requests/DistributesRoomRequest.php
@@ -52,6 +52,8 @@ class DistributesRoomRequest extends FormRequest
     public function rules()
     {
         return [
+            'sync_enrollment' => 'nullable|boolean',
+
             'rooms_id' => 'required|array',
             'rooms_id.*' => 'required|numeric',
 

--- a/app/Jobs/ProcessRoomDistribution.php
+++ b/app/Jobs/ProcessRoomDistribution.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Models\SchoolClass;
 use App\Models\SchoolTerm;
 use App\Models\SolverLog;
 use App\Services\RoomAllocationPayloadBuilder;
@@ -23,6 +24,7 @@ class ProcessRoomDistribution implements ShouldQueue, ShouldBeUnique
     public int $schoolTermId;
     public array $roomIds;
     public array $solverConfig;
+    public bool $syncEnrollment;
 
     public int $timeout = 60;
     public int $tries = 3;
@@ -31,11 +33,12 @@ class ProcessRoomDistribution implements ShouldQueue, ShouldBeUnique
     /**
      * Create a new job instance.
      */
-    public function __construct(int $schoolTermId, array $roomIds, array $solverConfig = [])
+    public function __construct(int $schoolTermId, array $roomIds, array $solverConfig = [], bool $syncEnrollment = false)
     {
         $this->schoolTermId = $schoolTermId;
         $this->roomIds = $roomIds;
         $this->solverConfig = $solverConfig;
+        $this->syncEnrollment = $syncEnrollment;
     }
 
     /**
@@ -52,6 +55,20 @@ class ProcessRoomDistribution implements ShouldQueue, ShouldBeUnique
     public function handle(): void
     {
         $term = SchoolTerm::findOrFail($this->schoolTermId);
+
+        if ($this->syncEnrollment) {
+            Log::info('ProcessRoomDistribution: syncing enrollment from Replicado', [
+                'school_term_id' => $this->schoolTermId,
+            ]);
+
+            SchoolClass::whereBelongsTo($term)
+                ->chunkById(100, function ($classes) {
+                    foreach ($classes as $class) {
+                        $class->calcEstimadedEnrollment();
+                        $class->save();
+                    }
+                });
+        }
 
         $payload = (new RoomAllocationPayloadBuilder())->build($term, $this->roomIds, $this->solverConfig);
 

--- a/app/Services/RoomAllocationPayloadBuilder.php
+++ b/app/Services/RoomAllocationPayloadBuilder.php
@@ -207,12 +207,23 @@ class RoomAllocationPayloadBuilder
         $classIds = array_map(fn ($c) => $c->id, $classes);
         $representative = $classes[0];
 
-        $tiptur = 'Pós Graduação';
+        $hasGraduacao = false;
+        $hasPosGraduacao = false;
+
         foreach ($classes as $class) {
             if ($class->tiptur === 'Graduação') {
-                $tiptur = 'Graduação';
-                break;
+                $hasGraduacao = true;
+            } elseif ($class->tiptur === 'Pós Graduação') {
+                $hasPosGraduacao = true;
             }
+        }
+
+        if ($hasGraduacao && $hasPosGraduacao) {
+            $tiptur = 'Mista';
+        } elseif ($hasGraduacao) {
+            $tiptur = 'Graduação';
+        } else {
+            $tiptur = 'Pós Graduação';
         }
 
         $adjustedDemands = [];

--- a/config/alocacao.php
+++ b/config/alocacao.php
@@ -57,7 +57,7 @@ return [
     */
     'room_allocation' => [
         'strict_capacity' => (bool) env('ROOM_ALLOCATION_STRICT_CAPACITY', true),
-        'block_b_restriction_for_pos' => (bool) env('ROOM_ALLOCATION_BLOCK_B_POS', true),
+        'block_b_restriction_for_pos' => (bool) env('ROOM_ALLOCATION_BLOCK_B_POS', false),
         'block_a_restriction_for_freshmen' => (bool) env('ROOM_ALLOCATION_BLOCK_A_FRESHMEN', true),
         'undergrad_in_block_a_penalty' => (float) env('ROOM_ALLOCATION_UNDERGRAD_BLOCK_A_PENALTY', 500.0),
         'pos_in_block_b_penalty' => (float) env('ROOM_ALLOCATION_POS_BLOCK_B_PENALTY', 500.0),

--- a/resources/views/rooms/index.blade.php
+++ b/resources/views/rooms/index.blade.php
@@ -282,6 +282,7 @@
 @php
 $tooltips = [
     'strict_capacity' => 'Quando ativada, o solver não pode alocar turmas em salas com capacidade menor que a demanda.',
+    'sync_enrollment' => 'Atualiza o número de inscritos (estmtr) diretamente do Replicado antes de executar o solver.',
     'block_b_restriction_for_pos' => 'Quando ativada, pós-graduação não pode ser alocada no Bloco B.',
     'block_a_restriction_for_freshmen' => 'Quando ativada, calouros do IME devem ser alocados no Bloco A.',
     'undergrad_in_block_a_penalty' => 'Penalidade aplicada ao alocar graduação no Bloco A (deveria ser preferencialmente no Bloco B).',
@@ -355,6 +356,22 @@ $tooltips = [
                                     </div>
                                 </div>
                             @endforeach
+
+                            <div class="col-md-4">
+                                <div class="form-group">
+                                    <div class="custom-control custom-switch">
+                                        <input type="hidden" name="sync_enrollment" value="0" form="distributesForm">
+                                        <input type="checkbox" class="custom-control-input" id="sync_enrollment"
+                                            name="sync_enrollment" value="1"
+                                            form="distributesForm"
+                                            checked>
+                                        <label class="custom-control-label" for="sync_enrollment"
+                                            data-toggle="tooltip" data-placement="top" title="{{ $tooltips['sync_enrollment'] }}">
+                                            Atualizar inscritos (Replicado)
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
 

--- a/resources/views/rooms/show.blade.php
+++ b/resources/views/rooms/show.blade.php
@@ -105,6 +105,8 @@
                                                         @php
                                                             $dobradinha = "";
                                                             $label = "";
+                                                            $totalEstimado = $turma->fusion->schoolclasses->sum('estmtr');
+                                                            $label .= "Total estimado de matriculados " . ($totalEstimado > 0 ? $totalEstimado : 'não disponível') . "\n";
                                                             $nomdis = $turma->fusion->schoolclasses->pluck("nomdis")->unique()->toArray();
                                                             if($turma->fusion->schoolclasses->pluck("coddis")->unique()->count() == 1){
                                                                 $dobradinha .= $turma->fusion->schoolclasses[0]->coddis." ";
@@ -137,7 +139,7 @@
                                                             }
                                                     
                                                         @endphp
-                                                        {{$dobradinha}}                                                                                                                  
+                                                        <span class="text-dark" title="{{ $label }}">{{$dobradinha}}</span>
                                                     @else
                                                         @if($turma->tiptur=="Graduação")
                                                             @php
@@ -151,7 +153,11 @@
                                                                 {{ $turma->coddis." T.".substr($turma->codtur, -2, 2) }}
                                                             </a>
                                                         @else
-                                                            {{ $turma->coddis }}
+                                                            @php
+                                                                $label = $turma->nomdis;
+                                                                $label .= "\n". ($turma->estmtr ? "Número estimado de matriculados ".$turma->estmtr : "Não foram encontrados registros anteriores para calcular uma estimativa de matriculados");
+                                                            @endphp
+                                                            <span class="text-dark" title="{{ $label }}">{{ $turma->coddis }}</span>
                                                         @endif
                                                         
                                                     @endif

--- a/tests/Unit/RoomAllocationPayloadBuilderTest.php
+++ b/tests/Unit/RoomAllocationPayloadBuilderTest.php
@@ -108,6 +108,43 @@ class RoomAllocationPayloadBuilderTest extends TestCase
     }
 
     /** @test */
+    public function it_sets_tiptur_to_mixed_for_fusion_with_graduation_and_post_graduation()
+    {
+        $term = SchoolTerm::factory()->create();
+        $room = Room::factory()->create();
+
+        $fusion = Fusion::factory()->create();
+        $classA = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'coddis' => 'MAT2453',
+            'codtur' => '20241',
+            'tiptur' => 'Graduação',
+            'estmtr' => 40,
+            'fusion_id' => $fusion->id,
+        ]);
+        $classB = SchoolClass::factory()->create([
+            'school_term_id' => $term->id,
+            'coddis' => 'MAT6660',
+            'codtur' => '20241',
+            'tiptur' => 'Pós Graduação',
+            'estmtr' => 20,
+            'fusion_id' => $fusion->id,
+        ]);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $classA->classschedules()->attach($schedule);
+        $classB->classschedules()->attach($schedule);
+
+        $builder = new RoomAllocationPayloadBuilder();
+        $payload = $builder->build($term, [$room->id]);
+
+        $group = $payload['groups'][0];
+        $this->assertEquals('fusion', $group['type']);
+        $this->assertEquals('Mista', $group['tiptur']);
+        $this->assertEquals(60, $group['demand']);
+    }
+
+    /** @test */
     public function it_builds_payload_for_fusion_with_partial_null_enrollment()
     {
         $term = SchoolTerm::factory()->create();
@@ -285,17 +322,17 @@ class RoomAllocationPayloadBuilderTest extends TestCase
         $this->assertArrayHasKey('priority_weight', $payload['config']);
 
         $this->assertTrue($payload['config']['strict_capacity']);
-        $this->assertTrue($payload['config']['block_b_restriction_for_pos']);
+        $this->assertFalse($payload['config']['block_b_restriction_for_pos']);
         $this->assertTrue($payload['config']['block_a_restriction_for_freshmen']);
         $this->assertEquals(500.0, $payload['config']['undergrad_in_block_a_penalty']);
         $this->assertEquals(500.0, $payload['config']['pos_in_block_b_penalty']);
         $this->assertEquals(1.0, $payload['config']['waste_penalty']);
-        $this->assertEquals(1.0, $payload['config']['claustrophobia_penalty']);
+        $this->assertEquals(7.0, $payload['config']['claustrophobia_penalty']);
         $this->assertEquals(10.0, $payload['config']['comfort_zone_min_percent']);
         $this->assertEquals(25.0, $payload['config']['comfort_zone_max_percent']);
-        $this->assertEquals(1.0, $payload['config']['split_class_penalty']);
-        $this->assertEquals(1.0, $payload['config']['split_cohort_penalty']);
-        $this->assertEquals(1000.0, $payload['config']['unassigned_penalty']);
+        $this->assertEquals(97780.0, $payload['config']['split_class_penalty']);
+        $this->assertEquals(9635.0, $payload['config']['split_cohort_penalty']);
+        $this->assertEquals(1745715.0, $payload['config']['unassigned_penalty']);
         $this->assertEquals(0.0, $payload['config']['priority_weight']);
 
         $this->assertIsFloat($payload['config']['waste_penalty']);
@@ -324,7 +361,7 @@ class RoomAllocationPayloadBuilderTest extends TestCase
 
         $this->assertTrue($payload['config']['strict_capacity']);
         $this->assertEquals(5.0, $payload['config']['waste_penalty']);
-        $this->assertTrue($payload['config']['block_b_restriction_for_pos']);
+        $this->assertFalse($payload['config']['block_b_restriction_for_pos']);
     }
 
     /** @test */


### PR DESCRIPTION
## Resumo

Implementa os três ajustes cirúrgicos solicitados na issue #77 para otimizar a alocação de salas do IME.

## Mudanças

### 1. Sincronização Dinâmica de Inscritos (On-the-fly)
- Adicionado checkbox **"Atualizar inscritos (Replicado)"** no modal `solverConfigModal` (`resources/views/rooms/index.blade.php`), marcado por padrão.
- A flag `sync_enrollment` é enviada na requisição `PATCH /rooms/distributes` e validada em `DistributesRoomRequest`.
- O `RoomController` repassa a flag ao job `ProcessRoomDistribution`.
- No job, quando a flag está ativa, todas as turmas do semestre letivo atual são iteradas e atualizadas via `$class->calcEstimadedEnrollment(); $class->save();`.
- A execução ocorre de forma assíncrona dentro do Job, evitando *timeout* na requisição HTTP.

### 2. Liberação da Pós-Graduação no Bloco B
- Alterado o valor padrão de `block_b_restriction_for_pos` para `false` em:
  - `config/alocacao.php`
  - `.env.example`
- O switch "Restrição Bloco B p/ Pós" no modal reflete o novo padrão (desmarcado).
- A penalidade flexível de 500 pontos (`pos_in_block_b_penalty`) continua protegendo o Bloco A, cedendo ao Bloco B apenas quando a demanda exigir.

### 3. Dobradinhas "Mistas"
- No `RoomAllocationPayloadBuilder::buildSingleGroup`, quando uma fusão possui turmas de **Graduação** e **Pós-Graduação** simultaneamente, o campo `tiptur` é definido como `"Mista"`.
- Como o solver Python aplica multas direcionais apenas para strings estritas `"graduacao"` ou `"pos graduacao"`, fusões "Mistas" ficam isentas dessas multas, deixando a decisão a cargo da capacidade e zona de conforto.

### 4. Testes
- Corrigidas expectativas de configuração padrão no `RoomAllocationPayloadBuilderTest` para refletir os valores reais do `config/alocacao.php`.
- Adicionado teste `it_sets_tiptur_to_mixed_for_fusion_with_graduation_and_post_graduation` garantindo o contrato JSON com `"tiptur": "Mista"`.

## Critérios de Aceite

- [x] Checkbox de atualização de inscritos presente e marcado por padrão.
- [x] Sincronização executada no Job quando a flag está ativa.
- [x] Padrão `block_b_restriction_for_pos` alterado para `false`.
- [x] Fusões mistas geram `"tiptur": "Mista"` no payload.
- [x] Testes do payload builder passando.

## Como Testar

```bash
docker compose exec -T app php artisan test --filter=RoomAllocationPayloadBuilderTest
docker compose exec -T app php artisan test --filter=ProcessRoomDistributionTest
docker compose exec -T app php artisan test --filter=DistributionFlowTest
```

Closes #77
