### PR TITLE
feat(comparison): estrutura de dados para Relatórios de Comparação (issue #79)

### DIFF
--- a/app/Models/ComparisonReport.php
+++ b/app/Models/ComparisonReport.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ComparisonReport extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'school_term_id',
+        'base_allocation_state_id',
+        'status',
+        'legacy_metrics',
+        'solver_metrics',
+        'legacy_raw_allocations',
+        'solver_raw_allocations',
+    ];
+
+    protected $casts = [
+        'legacy_metrics' => 'array',
+        'solver_metrics' => 'array',
+        'legacy_raw_allocations' => 'array',
+        'solver_raw_allocations' => 'array',
+    ];
+
+    public function schoolTerm()
+    {
+        return $this->belongsTo(SchoolTerm::class);
+    }
+
+    public function baseAllocationState()
+    {
+        return $this->belongsTo(AllocationState::class, 'base_allocation_state_id');
+    }
+}

--- a/database/factories/AllocationStateFactory.php
+++ b/database/factories/AllocationStateFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AllocationState;
+use App\Models\SchoolTerm;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class AllocationStateFactory extends Factory
+{
+    /**
+     * The name of the model's corresponding factory.
+     *
+     * @var string
+     */
+    protected $model = AllocationState::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'school_term_id' => SchoolTerm::factory(),
+            'name' => $this->faker->words(3, true),
+            'allocations' => [],
+            'solver_log_id' => null,
+        ];
+    }
+}

--- a/database/factories/ComparisonReportFactory.php
+++ b/database/factories/ComparisonReportFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AllocationState;
+use App\Models\ComparisonReport;
+use App\Models\SchoolTerm;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ComparisonReportFactory extends Factory
+{
+    /**
+     * The name of the model's corresponding factory.
+     *
+     * @var string
+     */
+    protected $model = ComparisonReport::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'school_term_id' => SchoolTerm::factory(),
+            'base_allocation_state_id' => AllocationState::factory(),
+            'status' => 'processing',
+            'legacy_metrics' => null,
+            'solver_metrics' => null,
+            'legacy_raw_allocations' => null,
+            'solver_raw_allocations' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_06_22_000000_create_comparison_reports_table.php
+++ b/database/migrations/2026_06_22_000000_create_comparison_reports_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateComparisonReportsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('comparison_reports', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('school_term_id')->constrained('school_terms')->cascadeOnDelete();
+            $table->foreignId('base_allocation_state_id')->constrained('allocation_states')->cascadeOnDelete();
+            $table->string('status', 20)->default('processing');
+            $table->json('legacy_metrics')->nullable();
+            $table->json('solver_metrics')->nullable();
+            $table->json('legacy_raw_allocations')->nullable();
+            $table->json('solver_raw_allocations')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comparison_reports');
+    }
+}

--- a/tests/Unit/ComparisonReportTest.php
+++ b/tests/Unit/ComparisonReportTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\AllocationState;
+use App\Models\ComparisonReport;
+use App\Models\SchoolTerm;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ComparisonReportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_can_be_created_with_fillable_attributes()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = AllocationState::factory()->create(['school_term_id' => $term->id]);
+
+        $report = ComparisonReport::create([
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $state->id,
+            'status' => 'processing',
+        ]);
+
+        $this->assertDatabaseHas('comparison_reports', [
+            'id' => $report->id,
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $state->id,
+            'status' => 'processing',
+        ]);
+    }
+
+    /** @test */
+    public function status_defaults_to_processing()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = AllocationState::factory()->create(['school_term_id' => $term->id]);
+
+        $report = ComparisonReport::create([
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $state->id,
+        ]);
+
+        $this->assertSame('processing', $report->fresh()->status);
+    }
+
+    /** @test */
+    public function json_fields_are_cast_to_arrays()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = AllocationState::factory()->create(['school_term_id' => $term->id]);
+
+        $report = ComparisonReport::create([
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $state->id,
+            'legacy_metrics' => ['allocation_rate' => 95.5, 'comfort_zone_rate' => 80.0],
+            'solver_metrics' => ['allocation_rate' => 98.2, 'comfort_zone_rate' => 92.1],
+            'legacy_raw_allocations' => [1 => 10, 2 => 20],
+            'solver_raw_allocations' => [1 => 11, 2 => 21],
+        ]);
+
+        $report = $report->fresh();
+
+        $this->assertIsArray($report->legacy_metrics);
+        $this->assertIsArray($report->solver_metrics);
+        $this->assertIsArray($report->legacy_raw_allocations);
+        $this->assertIsArray($report->solver_raw_allocations);
+
+        $this->assertSame(95.5, $report->legacy_metrics['allocation_rate']);
+        $this->assertSame(98.2, $report->solver_metrics['allocation_rate']);
+        $this->assertSame(10, $report->legacy_raw_allocations[1]);
+        $this->assertSame(21, $report->solver_raw_allocations[2]);
+    }
+
+    /** @test */
+    public function json_fields_can_be_null_by_default()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = AllocationState::factory()->create(['school_term_id' => $term->id]);
+
+        $report = ComparisonReport::create([
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $state->id,
+        ]);
+
+        $report = $report->fresh();
+
+        $this->assertNull($report->legacy_metrics);
+        $this->assertNull($report->solver_metrics);
+        $this->assertNull($report->legacy_raw_allocations);
+        $this->assertNull($report->solver_raw_allocations);
+    }
+
+    /** @test */
+    public function json_casts_survive_round_trips()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = AllocationState::factory()->create(['school_term_id' => $term->id]);
+
+        $nested = [
+            'kpis' => [
+                'allocation_rate' => 100.0,
+                'comfort_zone_rate' => 50.0,
+            ],
+            'solve_time_seconds' => 12.34,
+        ];
+
+        $report = ComparisonReport::create([
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $state->id,
+            'solver_metrics' => $nested,
+        ]);
+
+        $persisted = $report->fresh()->solver_metrics;
+        $this->assertEquals($nested['kpis']['allocation_rate'], $persisted['kpis']['allocation_rate']);
+        $this->assertEquals($nested['kpis']['comfort_zone_rate'], $persisted['kpis']['comfort_zone_rate']);
+        $this->assertSame($nested['solve_time_seconds'], $persisted['solve_time_seconds']);
+    }
+
+    /** @test */
+    public function it_belongs_to_school_term()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = AllocationState::factory()->create(['school_term_id' => $term->id]);
+
+        $report = ComparisonReport::create([
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $state->id,
+        ]);
+
+        $this->assertInstanceOf(SchoolTerm::class, $report->schoolTerm);
+        $this->assertSame($term->id, $report->schoolTerm->id);
+    }
+
+    /** @test */
+    public function it_belongs_to_base_allocation_state()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = AllocationState::factory()->create(['school_term_id' => $term->id]);
+
+        $report = ComparisonReport::create([
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $state->id,
+        ]);
+
+        $this->assertInstanceOf(AllocationState::class, $report->baseAllocationState);
+        $this->assertSame($state->id, $report->baseAllocationState->id);
+    }
+
+    /** @test */
+    public function deleting_school_term_cascades_to_report()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = AllocationState::factory()->create(['school_term_id' => $term->id]);
+
+        $report = ComparisonReport::create([
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $state->id,
+        ]);
+
+        $term->delete();
+
+        $this->assertDatabaseMissing('comparison_reports', ['id' => $report->id]);
+    }
+
+    /** @test */
+    public function deleting_base_allocation_state_cascades_to_report()
+    {
+        $term = SchoolTerm::factory()->create();
+        $state = AllocationState::factory()->create(['school_term_id' => $term->id]);
+
+        $report = ComparisonReport::create([
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $state->id,
+        ]);
+
+        $state->delete();
+
+        $this->assertDatabaseMissing('comparison_reports', ['id' => $report->id]);
+    }
+}


### PR DESCRIPTION
## Resumo

Implementa a estrutura de persistência (migration + model + factory) para os relatórios de comparação A/B entre a heurística legada e o solver CP-SAT, conforme definido na seção 4.1 do Documento de Arquitetura de Benchmarking.

## Mudanças

### Migration `create_comparison_reports_table`
- Tabela `comparison_reports` com:
  - `id` (PK)
  - `school_term_id` (FK para `school_terms`, cascade on delete)
  - `base_allocation_state_id` (FK para `allocation_states`, cascade on delete) — estado inicial com travas manuais
  - `status` (string, default `processing`) — valores previstos: `processing`, `completed`, `failed`
  - `legacy_metrics`, `solver_metrics`, `legacy_raw_allocations`, `solver_raw_allocations` (JSON, anuláveis)
  - `created_at`, `updated_at`

### Model `ComparisonReport`
- `$fillable` com todos os campos atribuíveis em massa.
- `$casts` mapeando os quatro campos JSON para `array` (cast nativo do PHP).
- Relacionamentos `belongsTo`: `schoolTerm()` e `baseAllocationState()` (referenciando `AllocationState` via `base_allocation_state_id`).

### Factories
- `ComparisonReportFactory` para suportar testes futuros do Job/Webhook.
- `AllocationStateFactory` (criada ausente) para permitir `AllocationState::factory()` encadeado na factory do relatório e nos testes.

### Testes (`tests/Unit/ComparisonReportTest.php`)
9 testes unitários cobrindo os critérios de aceite:
- Gravação dos atributos *fillable*.
- Default de `status = processing`.
- Casts JSON → array nativo do PHP (leitura e estrutura aninhada).
- Nulabilidade dos campos JSON antes do preenchimento.
- Round-trip de JSON complexo (KPIs aninhados + float).
- Relacionamentos `belongsTo` com `SchoolTerm` e `AllocationState`.
- Cascade delete ao remover `SchoolTerm` e `AllocationState`.

## Critérios de Aceite (DoD)

- [x] Migration roda com sucesso em SQLite em memória (suíte de testes) — compatível também com MySQL.
- [x] Model com `$casts` de JSON para array e relacionamentos `belongsTo`.
- [x] Testes unitários validando gravação, casts e relacionamentos.

## Como Testar

```bash
docker compose exec -T app php artisan test --filter=ComparisonReportTest
```

Resultado: `9 passed`.

> Observação: a suíte completa possui 6 falhas pré-existentes em `master` (`AllocationStateTest` e `DistributionFlowTest`), não relacionadas a esta mudança.

Closes #79
