### PR TITLE
feat(comparison): execução isolada e avaliação da heurística legada (issue #81)

### DIFF
--- a/app/Jobs/ProcessAlgorithmComparison.php
+++ b/app/Jobs/ProcessAlgorithmComparison.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\AllocationState;
+use App\Models\ComparisonReport;
+use App\Models\SchoolClass;
+use App\Models\SchoolTerm;
+use App\Services\AllocationEvaluatorService;
+use App\Services\AllocationStateService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use romanzipp\QueueMonitor\Traits\IsMonitored;
+
+class ProcessAlgorithmComparison implements ShouldQueue, ShouldBeUnique
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, IsMonitored;
+
+    public int $schoolTermId;
+    public int $baseAllocationStateId;
+    public array $roomIds;
+
+    public ?int $comparisonReportId = null;
+
+    public int $timeout = 1800;
+    public int $tries = 1;
+    public int $uniqueFor = 3600;
+
+    public function progressCooldown(): int
+    {
+        return 1;
+    }
+
+    public function __construct(int $schoolTermId, int $baseAllocationStateId, array $roomIds)
+    {
+        $this->schoolTermId = $schoolTermId;
+        $this->baseAllocationStateId = $baseAllocationStateId;
+        $this->roomIds = $roomIds;
+    }
+
+    public function uniqueId(): string
+    {
+        return 'algorithm-comparison-' . $this->schoolTermId;
+    }
+
+    public function handle(): void
+    {
+        $term = SchoolTerm::findOrFail($this->schoolTermId);
+        $baseState = AllocationState::findOrFail($this->baseAllocationStateId);
+
+        $report = ComparisonReport::create([
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $baseState->id,
+            'status' => 'processing',
+        ]);
+        $this->comparisonReportId = $report->id;
+
+        // Snapshot do cache de progresso de alocacao para garantir que a
+        // execucao da heuristica legada (que escreve no cache de producao)
+        // nao perturbe o estado visto por usuarios reais. Ao final, o cache
+        // e restaurado ao seu valor original.
+        $cacheKey = "allocation:{$term->id}";
+        $previousCache = Cache::get($cacheKey);
+
+        $legacyAllocations = [];
+        $solveStart = microtime(true);
+
+        try {
+            DB::beginTransaction();
+
+            // 1. Restaura o estado base (travas manuais) como ponto de
+            //    partida identico para a heuristica legada.
+            AllocationStateService::restore($baseState);
+
+            // 2. Executa a heuristica legada sincronamente dentro do
+            //    contexto transacional. Suas escritas em school_classes
+            //    ficam confinadas a esta transacao reversivel.
+            $legacyJob = new ProcessLegacyRoomDistribution($term->id, $this->roomIds);
+            $legacyJob->handle();
+
+            // 3. Coleta imediatamente o mapa resultante [class_id => room_id]
+            //    antes de qualquer rollback.
+            $legacyAllocations = $this->collectRawAllocations($term);
+
+            // 4. Aborta a transacao IMEDIATAMENTE para garantir que o banco
+            //    de producao permaneca intacto (side-effect free).
+            DB::rollBack();
+        } catch (\Throwable $e) {
+            if (DB::transactionLevel() > 0) {
+                DB::rollBack();
+            }
+
+            $this->restoreCache($cacheKey, $previousCache);
+
+            $report->update(['status' => 'failed']);
+
+            throw $e;
+        }
+
+        $solveTime = microtime(true) - $solveStart;
+        $this->restoreCache($cacheKey, $previousCache);
+
+        // 5. Avaliacao isomorfica do resultado legado via Evaluator (puro,
+        //    sem escrita em DB). O mapa coletado ja esta em memoria, logo o
+        //    rollback do banco nao o afeta.
+        $evaluator = new AllocationEvaluatorService();
+        $legacyMetrics = $evaluator->evaluate($term, $legacyAllocations, $solveTime);
+
+        // 6. Persiste as metricas e o mapa bruto do legado. O relatorio
+        //    permanece em 'processing' ate que o solver seja avaliado
+        //    (fluxo do webhook, tratado em issue dedicada).
+        $report->update([
+            'legacy_metrics' => $legacyMetrics,
+            'legacy_raw_allocations' => $legacyAllocations,
+        ]);
+
+        Log::info('ProcessAlgorithmComparison: legacy phase concluded', [
+            'comparison_report_id' => $report->id,
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $baseState->id,
+            'allocated_count' => count(array_filter($legacyAllocations, fn ($id) => $id !== null)),
+        ]);
+    }
+
+    /**
+     * Constroi o mapa bruto [class_id => room_id] a partir do estado atual
+     * das turmas, resolvido da mesma forma que AllocationStateService::capture
+     * (mestre de fusao tem precedencia).
+     *
+     * @return array<int, int|null>
+     */
+    protected function collectRawAllocations(SchoolTerm $term): array
+    {
+        $allocations = [];
+
+        $classes = SchoolClass::whereBelongsTo($term)
+            ->with(['fusion.master', 'fusion.schoolclasses'])
+            ->get();
+
+        foreach ($classes as $class) {
+            $allocations[$class->id] = $this->resolveRoomId($class);
+        }
+
+        return $allocations;
+    }
+
+    protected function resolveRoomId(SchoolClass $class): ?int
+    {
+        if ($class->fusion_id && $class->fusion) {
+            $master = $class->fusion->master;
+
+            if ($master && $master->room_id) {
+                return $master->room_id;
+            }
+
+            foreach ($class->fusion->schoolclasses as $child) {
+                if ($child->room_id) {
+                    return $child->room_id;
+                }
+            }
+
+            return null;
+        }
+
+        return $class->room_id;
+    }
+
+    /**
+     * Restaura o cache de progresso de alocacao ao seu valor anterior a
+     * execucao da heuristica legada, garantindo que usuarios de producao
+     * nao observem estado espurio de "concluido" pelo benchmarking.
+     */
+    /**
+     * @param  string  $cacheKey
+     * @param  array|null  $previousCache
+     * @return void
+     */
+    protected function restoreCache(string $cacheKey, $previousCache): void
+    {
+        if ($previousCache === null) {
+            Cache::forget($cacheKey);
+
+            return;
+        }
+
+        Cache::put($cacheKey, $previousCache, now()->addHours(4));
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        if ($this->comparisonReportId !== null) {
+            ComparisonReport::where('id', $this->comparisonReportId)->update([
+                'status' => 'failed',
+            ]);
+        }
+
+        Log::error('ProcessAlgorithmComparison: failed', [
+            'school_term_id' => $this->schoolTermId,
+            'base_allocation_state_id' => $this->baseAllocationStateId,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/tests/Feature/ProcessAlgorithmComparisonTest.php
+++ b/tests/Feature/ProcessAlgorithmComparisonTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ProcessAlgorithmComparison;
+use App\Models\AllocationState;
+use App\Models\ClassSchedule;
+use App\Models\ComparisonReport;
+use App\Models\Room;
+use App\Models\SchoolClass;
+use App\Models\SchoolTerm;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class ProcessAlgorithmComparisonTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_has_correct_unique_id()
+    {
+        $job = new ProcessAlgorithmComparison(42, 7, [1, 2]);
+        $this->assertEquals('algorithm-comparison-42', $job->uniqueId());
+    }
+
+    /** @test */
+    public function it_creates_a_comparison_report_with_processing_status()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => null],
+            'solver_log_id' => null,
+        ]);
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        $this->assertDatabaseHas('comparison_reports', [
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $baseState->id,
+            'status' => 'processing',
+        ]);
+    }
+
+    /** @test */
+    public function it_populates_legacy_metrics_and_raw_allocations()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => null],
+            'solver_log_id' => null,
+        ]);
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        $report = ComparisonReport::first();
+
+        $this->assertNotNull($report);
+        $this->assertNotNull($report->legacy_metrics);
+        $this->assertArrayHasKey('allocation_rate', $report->legacy_metrics);
+        $this->assertArrayHasKey('comfort_zone_rate', $report->legacy_metrics);
+        $this->assertArrayHasKey('avg_waste_per_class', $report->legacy_metrics);
+        $this->assertArrayHasKey('avg_claustrophobia_per_class', $report->legacy_metrics);
+        $this->assertArrayHasKey('block_adherence_rate', $report->legacy_metrics);
+        $this->assertArrayHasKey('solve_time_seconds', $report->legacy_metrics);
+
+        $this->assertNotNull($report->legacy_raw_allocations);
+        $this->assertArrayHasKey($class->id, $report->legacy_raw_allocations);
+        $this->assertEquals($room->id, $report->legacy_raw_allocations[$class->id]);
+
+        // Solver ainda nao foi avaliado neste fluxo (issue dedicada).
+        $this->assertNull($report->solver_metrics);
+        $this->assertNull($report->solver_raw_allocations);
+    }
+
+    /** @test */
+    public function it_does_not_mutate_production_database()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        // Estado de producao anterior: turma sem sala.
+        $this->assertNull($class->fresh()->room_id);
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => null],
+            'solver_log_id' => null,
+        ]);
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        // DoD: o banco de producao DEVE continuar intacto. A turma nao pode
+        // permanecer alocada apos o benchmarking.
+        $this->assertNull($class->fresh()->room_id);
+
+        // Nenhum AllocationState residual de "Pré-Legado" deve persistir
+        // (a capture interna do legado e envelopada pela transacao revertida).
+        $this->assertEquals(1, AllocationState::count());
+    }
+
+    /** @test */
+    public function it_does_not_disturb_production_allocation_cache()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        $cacheKey = "allocation:{$term->id}";
+        Cache::put($cacheKey, [
+            'job_id' => 'abc',
+            'status' => 'solving',
+            'mode' => 'solver',
+        ], now()->addHours(4));
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => null],
+            'solver_log_id' => null,
+        ]);
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        $cached = Cache::get($cacheKey);
+        $this->assertNotNull($cached);
+        $this->assertEquals('solver', $cached['mode']);
+        $this->assertEquals('solving', $cached['status']);
+    }
+
+    /** @test */
+    public function it_clears_allocation_cache_when_none_existed_before()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => null],
+            'solver_log_id' => null,
+        ]);
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        $this->assertNull(Cache::get("allocation:{$term->id}"));
+    }
+
+    /** @test */
+    public function it_restores_base_state_as_starting_point_for_legacy()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        // Simula uma pre-alocacao manual (trava) definida pela comissao que
+        // deve servir de ponto de partida para a heuristica legada.
+        $manualRoom = Room::factory()->blockA()->create(['assentos' => 200]);
+        $class->room_id = $manualRoom->id;
+        $class->save();
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => $manualRoom->id],
+            'solver_log_id' => null,
+        ]);
+
+        // Estado de producao atual: turma sem sala (diferente do base).
+        $class->room_id = null;
+        $class->save();
+        $this->assertNull($class->fresh()->room_id);
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        $report = ComparisonReport::first();
+
+        // A heuristica legada respeita o guard de "ja alocada" (room existe),
+        // logo a turma deve permanecer na sala manual do estado base e o mapa
+        // coletado deve refletir essa sala.
+        $this->assertEquals($manualRoom->id, $report->legacy_raw_allocations[$class->id]);
+
+        // Banco de producao permanece intacto (sem sala).
+        $this->assertNull($class->fresh()->room_id);
+    }
+
+    /** @test */
+    public function it_marks_report_failed_via_failed_callback()
+    {
+        $term = $this->latestTerm();
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [],
+            'solver_log_id' => null,
+        ]);
+
+        $report = ComparisonReport::create([
+            'school_term_id' => $term->id,
+            'base_allocation_state_id' => $baseState->id,
+            'status' => 'processing',
+        ]);
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [1]);
+        $job->comparisonReportId = $report->id;
+
+        $job->failed(new \RuntimeException('boom'));
+
+        $this->assertEquals('failed', $report->fresh()->status);
+    }
+
+    /** @test */
+    public function it_does_not_create_report_when_base_state_is_missing()
+    {
+        $term = $this->latestTerm();
+
+        $job = new ProcessAlgorithmComparison($term->id, 999999, [1]);
+
+        try {
+            $job->handle();
+        } catch (\Throwable $e) {
+            // AllocationState::findOrFail lanca ModelNotFoundException.
+        }
+
+        $this->assertEquals(0, ComparisonReport::count());
+    }
+
+    private function latestTerm(): SchoolTerm
+    {
+        // AllocationStateService::restore utiliza SchoolTerm::getLatest(),
+        // logo o semestre do benchmark deve ser o mais recente.
+        return SchoolTerm::factory()->create([
+            'year' => now()->year + 1,
+            'period' => '2° Semestre',
+        ]);
+    }
+
+    private function allocatableClass(SchoolTerm $term): array
+    {
+        $room = Room::factory()->blockA()->create(['assentos' => 100]);
+
+        $class = SchoolClass::factory()
+            ->undergraduate()
+            ->withoutRoom()
+            ->withSchoolTerm($term)
+            ->create(['estmtr' => 30]);
+
+        $schedule = ClassSchedule::factory()->seg()->morning()->create();
+        $class->classschedules()->attach($schedule);
+
+        return [$room, $class];
+    }
+}


### PR DESCRIPTION
## Issue Relacionada

Closes #81

## Descrição

Adiciona o job assíncrono `ProcessAlgorithmComparison` que executa a heurística legada (`ProcessLegacyRoomDistribution`) em um ambiente destrutível confinado a uma transação reversível, avalia o resultado com o `AllocationEvaluatorService` e persiste as métricas em `comparison_reports` — sem jamais alterar o banco de produção.

### Fluxo implementado

1. Cria registro em `comparison_reports` com `status = 'processing'`.
2. Snapshot/restaura o cache de progresso de alocação (`allocation:{term}`) para não perturbar usuários de produção durante o benchmarking.
3. `DB::beginTransaction()`
   - `AllocationStateService::restore($baseState)` → restaura o estado base (travas manuais) como ponto de partida idêntico.
   - Instancia e executa `ProcessLegacyRoomDistribution` **sincronamente** dentro do contexto transacional.
   - Coleta imediatamente o mapa resultante `[class_id => room_id]` (resolvendo mestres de fusão como o `AllocationStateService`).
4. `DB::rollBack()` **imediato** → garante `school_classes.room_id` intacto (side-effect free).
5. Avalia o mapa coletado via `AllocationEvaluatorService` (puro, sem escrita em DB) e persiste `legacy_metrics` + `legacy_raw_allocations`.
6. O relatório permanece `'processing'` até a fase do solver (webhook dedicado, tratado em issue separada). Em falha, marca `'failed'`.

## Tipo de Mudança

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor / cosmetic
- [ ] Documentation

## Como foi testado

Suite de feature tests em `tests/Feature/ProcessAlgorithmComparisonTest.php` (9 testes), executada no container Docker (`php artisan test`):

- `it does not mutate production database` — **DoD**: garante que `school_classes.room_id` permanece intacto após o benchmarking e que nenhum `AllocationState` residual de "Pré-Legado" persiste.
- `it populates legacy metrics and raw allocations` — **DoD**: verifica que `legacy_metrics` (6 KPIs) e `legacy_raw_allocations` estão preenchidos.
- `it creates a comparison report with processing status` — criação do relatório com status correto.
- `it restores base state as starting point for legacy` — a heurística respeita as pré-alocações manuais do estado base.
- `it does not disturb production allocation cache` / `it clears allocation cache when none existed before` — preservação do cache de progresso.
- `it marks report failed via failed callback` — callback `failed()` marca o relatório como `'failed'`.
- `it does not create report when base state is missing` — robustez quando o estado base não existe.

## Pre-flight Checklist

- [x] O código segue o estilo/convenções do projeto (segue o padrão dos jobs existentes: `ShouldQueue`, `ShouldBeUnique`, `IsMonitored`, `uniqueId()`).
- [x] Testes adicionados que comprovam o funcionamento da feature.
- [ ] Testes existentes não foram afetados (suite de regressão: `ProcessLegacyRoomDistributionTest`, `ComparisonReportTest`, `AllocationEvaluatorServiceTest`, `AllocationStateTest` — todos passam).
