### PR TITLE
feat(comparison): disparo do solver CP-SAT para benchmarking (issue #82)

### DIFF
--- a/app/Http/Controllers/ComparisonResultWebhookController.php
+++ b/app/Http/Controllers/ComparisonResultWebhookController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class ComparisonResultWebhookController extends Controller
+{
+    /**
+     * Recebe o resultado assincrono do Solver CP-SAT para fins de
+     * Benchmarking (modulo de comparacao).
+     *
+     * A persistencia das solver_metrics e a transicao de status do
+     * ComparisonReport para 'completed' sao tratadas nesta issue dedicada
+     * (modulo de Benchmarking). Este controlador existe primariamente para
+     * que a rota `webhooks.comparison.result` seja resolvivel pelo helper
+     * route() no momento do disparo do Job `ProcessAlgorithmComparison`.
+     */
+    public function __invoke(Request $request)
+    {
+        Log::info('ComparisonResultWebhook: received solver result for benchmarking', [
+            'job_id' => $request->input('job_id'),
+            'status' => $request->input('status'),
+        ]);
+
+        return response()->json(['message' => 'accepted'], 202);
+    }
+}

--- a/app/Jobs/ProcessAlgorithmComparison.php
+++ b/app/Jobs/ProcessAlgorithmComparison.php
@@ -8,6 +8,7 @@ use App\Models\SchoolClass;
 use App\Models\SchoolTerm;
 use App\Services\AllocationEvaluatorService;
 use App\Services\AllocationStateService;
+use App\Services\RoomAllocationPayloadBuilder;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -16,6 +17,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use romanzipp\QueueMonitor\Traits\IsMonitored;
 
@@ -70,6 +72,7 @@ class ProcessAlgorithmComparison implements ShouldQueue, ShouldBeUnique
         $previousCache = Cache::get($cacheKey);
 
         $legacyAllocations = [];
+        $solverPayload = null;
         $solveStart = microtime(true);
 
         try {
@@ -79,17 +82,26 @@ class ProcessAlgorithmComparison implements ShouldQueue, ShouldBeUnique
             //    partida identico para a heuristica legada.
             AllocationStateService::restore($baseState);
 
-            // 2. Executa a heuristica legada sincronamente dentro do
+            // 2. Construi o payload do Solver CP-SAT A PARTIR do estado base
+            //    restaurado. As pre-alocacoes manuais (room_id) presentes no
+            //    estado base sao capturadas como `preassigned_room_id` no
+            //    payload, garantindo que o Solver inicie do mesmo ponto que a
+            //    heuristica legada. A construcao e pura (leituras), logo o
+            //    rollback posterior nao afeta o array em memoria.
+            $solverPayload = (new RoomAllocationPayloadBuilder())
+                ->build($term, $this->roomIds);
+
+            // 3. Executa a heuristica legada sincronamente dentro do
             //    contexto transacional. Suas escritas em school_classes
             //    ficam confinadas a esta transacao reversivel.
             $legacyJob = new ProcessLegacyRoomDistribution($term->id, $this->roomIds);
             $legacyJob->handle();
 
-            // 3. Coleta imediatamente o mapa resultante [class_id => room_id]
+            // 4. Coleta imediatamente o mapa resultante [class_id => room_id]
             //    antes de qualquer rollback.
             $legacyAllocations = $this->collectRawAllocations($term);
 
-            // 4. Aborta a transacao IMEDIATAMENTE para garantir que o banco
+            // 5. Aborta a transacao IMEDIATAMENTE para garantir que o banco
             //    de producao permaneca intacto (side-effect free).
             DB::rollBack();
         } catch (\Throwable $e) {
@@ -107,13 +119,13 @@ class ProcessAlgorithmComparison implements ShouldQueue, ShouldBeUnique
         $solveTime = microtime(true) - $solveStart;
         $this->restoreCache($cacheKey, $previousCache);
 
-        // 5. Avaliacao isomorfica do resultado legado via Evaluator (puro,
+        // 6. Avaliacao isomorfica do resultado legado via Evaluator (puro,
         //    sem escrita em DB). O mapa coletado ja esta em memoria, logo o
         //    rollback do banco nao o afeta.
         $evaluator = new AllocationEvaluatorService();
         $legacyMetrics = $evaluator->evaluate($term, $legacyAllocations, $solveTime);
 
-        // 6. Persiste as metricas e o mapa bruto do legado. O relatorio
+        // 7. Persiste as metricas e o mapa bruto do legado. O relatorio
         //    permanece em 'processing' ate que o solver seja avaliado
         //    (fluxo do webhook, tratado em issue dedicada).
         $report->update([
@@ -126,6 +138,117 @@ class ProcessAlgorithmComparison implements ShouldQueue, ShouldBeUnique
             'school_term_id' => $term->id,
             'base_allocation_state_id' => $baseState->id,
             'allocated_count' => count(array_filter($legacyAllocations, fn ($id) => $id !== null)),
+        ]);
+
+        // 8. Disparo do Solver CP-SAT para Benchmarking. O payload foi
+        //    construido a partir do estado base (passo 2) e agora e enviado
+        //    ao microsservico Python, apontando o webhook de retorno para a
+        //    rota exclusiva de comparacao. Falhas de conexao/disparo
+        //    finalizam o relatorio como 'failed' (evitando Jobs zumbis);
+        //    sucesso mantem 'processing' para aguardar o retorno assincrono.
+        $this->dispatchSolver($term, $report, $solverPayload);
+    }
+
+    /**
+     * Dispara o payload do Solver CP-SAT (microsservico Python) para fins de
+     * Benchmarking, injetando no bloco `meta` a URL do webhook de comparacao.
+     *
+     * O envio e best-effort em relacao ao status do relatorio: qualquer falha
+     * de conexao, HTTP de erro ou resposta invalida marca o relatorio como
+     * 'failed' e encerra o Job de forma limpa (sem relancar), preservando as
+     * legacy_metrics ja persistidas. Em sucesso, o relatorio permanece
+     * 'processing' aguardando o callback assincrono do Solver.
+     */
+    protected function dispatchSolver(SchoolTerm $term, ComparisonReport $report, ?array $payload): void
+    {
+        if ($payload === null) {
+            $report->update(['status' => 'failed']);
+            Log::error('ProcessAlgorithmComparison: solver payload missing', [
+                'comparison_report_id' => $report->id,
+                'school_term_id' => $term->id,
+            ]);
+
+            return;
+        }
+
+        $solverUrl = rtrim((string) config('alocacao.solver.url'), '/');
+        $apiToken = config('alocacao.solver.api_token');
+        $timeout = config('alocacao.solver.timeout', 60);
+
+        $webhookUrl = route('webhooks.comparison.result');
+
+        // Injeta no bloco meta do payload a URL de webhook especifica do
+        // escopo de Benchmarking (em vez da rota padrao de salvamento).
+        $payload['meta']['webhook_url'] = $webhookUrl;
+
+        Log::info('ProcessAlgorithmComparison: dispatching to solver', [
+            'comparison_report_id' => $report->id,
+            'school_term_id' => $term->id,
+            'solver_url' => $solverUrl,
+            'webhook_url' => $webhookUrl,
+        ]);
+
+        try {
+            $http = Http::withHeaders([
+                    'X-Webhook-Token' => $apiToken,
+                    'Accept' => 'application/json',
+                ])
+                ->timeout($timeout);
+
+            if (! config('alocacao.solver.verify_ssl', true)) {
+                $http = $http->withoutVerifying();
+            }
+
+            $response = $http->post("{$solverUrl}/api/v1/solve", $payload);
+        } catch (\Throwable $e) {
+            $report->update(['status' => 'failed']);
+            Log::error('ProcessAlgorithmComparison: solver connection failed', [
+                'comparison_report_id' => $report->id,
+                'school_term_id' => $term->id,
+                'solver_url' => $solverUrl,
+                'error' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        if (! $response->successful()) {
+            $report->update(['status' => 'failed']);
+            Log::error('ProcessAlgorithmComparison: solver returned error', [
+                'comparison_report_id' => $report->id,
+                'school_term_id' => $term->id,
+                'status' => $response->status(),
+                'body' => $response->body(),
+            ]);
+
+            return;
+        }
+
+        $jobId = $response->json('job_id');
+
+        if (empty($jobId)) {
+            $report->update(['status' => 'failed']);
+            Log::error('ProcessAlgorithmComparison: solver response missing job_id', [
+                'comparison_report_id' => $report->id,
+                'school_term_id' => $term->id,
+                'body' => $response->json(),
+            ]);
+
+            return;
+        }
+
+        // Indice secundario para que o webhook de comparacao consiga
+        // resolver job_id -> comparison_report_id no retorno assincrono.
+        Cache::put(
+            "comparison:job:{$jobId}",
+            $report->id,
+            now()->addHours(4)
+        );
+
+        Log::info('ProcessAlgorithmComparison: solver dispatched successfully', [
+            'comparison_report_id' => $report->id,
+            'school_term_id' => $term->id,
+            'job_id' => $jobId,
         ]);
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AllocationProgressWebhookController;
 use App\Http\Controllers\AllocationResultWebhookController;
+use App\Http\Controllers\ComparisonResultWebhookController;
 
 /*
 |--------------------------------------------------------------------------
@@ -25,3 +26,6 @@ Route::post('/webhooks/allocation-progress', AllocationProgressWebhookController
 
 Route::post('/webhooks/allocation-result', AllocationResultWebhookController::class)
     ->name('webhooks.allocation.result');
+
+Route::post('/webhooks/comparison-result', ComparisonResultWebhookController::class)
+    ->name('webhooks.comparison.result');

--- a/tests/Feature/ProcessAlgorithmComparisonTest.php
+++ b/tests/Feature/ProcessAlgorithmComparisonTest.php
@@ -11,11 +11,36 @@ use App\Models\SchoolClass;
 use App\Models\SchoolTerm;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class ProcessAlgorithmComparisonTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['alocacao.solver.url' => 'http://solver.test']);
+        config(['alocacao.solver.api_token' => 'test-token']);
+    }
+
+    /**
+     * Registra um fake do Solver que responde com sucesso (job_id valido),
+     * mantendo o relatorio em 'processing'. Deve ser chamado explicitamente
+     * nos testes que disparam o Job ate o fim esperando sucesso, pois o
+     * Http::fake do Laravel avalia todos os callbacks registrados (logo um
+     * fake default no setUp seria sempre vencedor sobre fakes de falha).
+     */
+    protected function fakeSolverSuccess(string $jobId = 'comparison-job-1'): void
+    {
+        Http::fake([
+            'http://solver.test/api/v1/solve' => Http::response([
+                'job_id' => $jobId,
+            ], 202),
+        ]);
+    }
 
     /** @test */
     public function it_has_correct_unique_id()
@@ -36,6 +61,8 @@ class ProcessAlgorithmComparisonTest extends TestCase
             'allocations' => [$class->id => null],
             'solver_log_id' => null,
         ]);
+
+        $this->fakeSolverSuccess();
 
         $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
         $job->handle();
@@ -60,6 +87,8 @@ class ProcessAlgorithmComparisonTest extends TestCase
             'solver_log_id' => null,
         ]);
 
+        $this->fakeSolverSuccess();
+
         $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
         $job->handle();
 
@@ -78,7 +107,8 @@ class ProcessAlgorithmComparisonTest extends TestCase
         $this->assertArrayHasKey($class->id, $report->legacy_raw_allocations);
         $this->assertEquals($room->id, $report->legacy_raw_allocations[$class->id]);
 
-        // Solver ainda nao foi avaliado neste fluxo (issue dedicada).
+        // Solver ainda nao foi avaliado neste fluxo (webhook dedicado).
+        // O disparo apenas mantem o relatorio em 'processing'.
         $this->assertNull($report->solver_metrics);
         $this->assertNull($report->solver_raw_allocations);
     }
@@ -98,6 +128,8 @@ class ProcessAlgorithmComparisonTest extends TestCase
             'allocations' => [$class->id => null],
             'solver_log_id' => null,
         ]);
+
+        $this->fakeSolverSuccess();
 
         $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
         $job->handle();
@@ -131,6 +163,8 @@ class ProcessAlgorithmComparisonTest extends TestCase
             'solver_log_id' => null,
         ]);
 
+        $this->fakeSolverSuccess();
+
         $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
         $job->handle();
 
@@ -152,6 +186,8 @@ class ProcessAlgorithmComparisonTest extends TestCase
             'allocations' => [$class->id => null],
             'solver_log_id' => null,
         ]);
+
+        $this->fakeSolverSuccess();
 
         $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
         $job->handle();
@@ -182,6 +218,8 @@ class ProcessAlgorithmComparisonTest extends TestCase
         $class->room_id = null;
         $class->save();
         $this->assertNull($class->fresh()->room_id);
+
+        $this->fakeSolverSuccess();
 
         $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
         $job->handle();
@@ -237,6 +275,168 @@ class ProcessAlgorithmComparisonTest extends TestCase
         }
 
         $this->assertEquals(0, ComparisonReport::count());
+    }
+
+    /** @test */
+    public function it_dispatches_solver_payload_with_comparison_webhook_url()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => null],
+            'solver_log_id' => null,
+        ]);
+
+        $this->fakeSolverSuccess();
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        $expectedWebhook = route('webhooks.comparison.result');
+
+        Http::assertSent(function ($request) use ($expectedWebhook, $room) {
+            $data = $request->data();
+            $this->assertArrayHasKey('meta', $data);
+            $this->assertArrayHasKey('webhook_url', $data['meta']);
+            $this->assertEquals($expectedWebhook, $data['meta']['webhook_url']);
+            $this->assertEquals([$room->id], array_column($data['rooms'], 'id'));
+
+            return true;
+        });
+    }
+
+    /** @test */
+    public function it_keeps_report_processing_and_caches_job_index_on_successful_dispatch()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => null],
+            'solver_log_id' => null,
+        ]);
+
+        $this->fakeSolverSuccess();
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        $report = ComparisonReport::first();
+
+        $this->assertEquals('processing', $report->status);
+        $this->assertEquals($report->id, Cache::get('comparison:job:comparison-job-1'));
+    }
+
+    /** @test */
+    public function it_marks_report_failed_when_solver_returns_http_error()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => null],
+            'solver_log_id' => null,
+        ]);
+
+        Http::fake([
+            'http://solver.test/api/v1/solve' => Http::response('Internal Server Error', 500),
+        ]);
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        $report = ComparisonReport::first();
+
+        $this->assertEquals('failed', $report->status);
+        // Legacy metrics ainda devem estar persistidas (nao relanca).
+        $this->assertNotNull($report->legacy_metrics);
+    }
+
+    /** @test */
+    public function it_marks_report_failed_when_solver_response_lacks_job_id()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => null],
+            'solver_log_id' => null,
+        ]);
+
+        Http::fake([
+            'http://solver.test/api/v1/solve' => Http::response(['status' => 'ok'], 200),
+        ]);
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        $this->assertEquals('failed', ComparisonReport::first()->status);
+    }
+
+    /** @test */
+    public function it_marks_report_failed_when_solver_is_offline()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => null],
+            'solver_log_id' => null,
+        ]);
+
+        Http::fake(function () {
+            throw new \Illuminate\Http\Client\ConnectionException('Could not resolve host');
+        });
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        $report = ComparisonReport::first();
+
+        $this->assertEquals('failed', $report->status);
+        $this->assertNotNull($report->legacy_metrics);
+    }
+
+    /** @test */
+    public function it_builds_solver_payload_from_base_state_preallocations()
+    {
+        $term = $this->latestTerm();
+        [$room, $class] = $this->allocatableClass($term);
+
+        // Pre-alocacao manual (trava) definida no estado base deve chegar ao
+        // Solver como preassigned_room_id.
+        $manualRoom = Room::factory()->blockA()->create(['assentos' => 200]);
+
+        $baseState = AllocationState::create([
+            'school_term_id' => $term->id,
+            'name' => 'Base de Benchmarking',
+            'allocations' => [$class->id => $manualRoom->id],
+            'solver_log_id' => null,
+        ]);
+
+        $this->fakeSolverSuccess();
+
+        $job = new ProcessAlgorithmComparison($term->id, $baseState->id, [$room->id]);
+        $job->handle();
+
+        Http::assertSent(function ($request) use ($manualRoom) {
+            $data = $request->data();
+            $groups = $data['groups'] ?? [];
+            $preassigned = collect($groups)->pluck('preassigned_room_id')->filter();
+
+            return $preassigned->contains($manualRoom->id);
+        });
     }
 
     private function latestTerm(): SchoolTerm


### PR DESCRIPTION
## Contexto

Continuando a implementação do job de Benchmarking (`ProcessAlgorithmComparison`), esta PR adiciona a **fase de disparo do Solver CP-SAT** (microsserviço Python) para fins de comparação com a heurística legada. Após a avaliação isolada do legado (issue #81), o Job agora constrói o payload a partir do estado base e o envia ao Solver, apontando o webhook de retorno para uma rota exclusiva do módulo de Benchmarking.

Refs: #82

## Tarefas (Checklist)

- [x] No Job `ProcessAlgorithmComparison` (após o rollback do passo anterior), utilizar o serviço `RoomAllocationPayloadBuilder` para gerar o payload JSON do problema baseado no `base_allocation_state_id`.
- [x] Injetar, dentro do bloco `meta` do Payload, URLs de webhooks específicos para o escopo de comparação (`route('webhooks.comparison.result')`).
- [x] Fazer a requisição HTTP POST para o endpoint do Python Solver (`/api/v1/solve`).
- [x] Tratar falhas de conexão no disparo (salvando o relatório com `status = failed` caso o Python esteja offline).
- [x] Manter o relatório em `processing` para aguardar o retorno assíncrono.

## Mudanças

- **`app/Jobs/ProcessAlgorithmComparison.php`**
  - O payload do Solver agora é construído **dentro da transação**, imediatamente após `AllocationStateService::restore($baseState)`, garantindo que as pré-alocações manuais do estado base sejam capturadas como `preassigned_room_id` (ponto de partida idêntico ao do legado). O array em memória não é afetado pelo `rollBack()`.
  - Novo método `dispatchSolver()`: injeta `meta.webhook_url = route('webhooks.comparison.result')`, realiza `POST {solver_url}/api/v1/solve` com o mesmo padrão de headers/timeout/SSL do `ProcessRoomDistribution`, e:
    - em **sucesso** (HTTP 2xx + `job_id` válido): cria o índice secundário em cache `comparison:job:{jobId}` → `comparison_report_id` e mantém o status `processing` para aguardar o callback assíncrono;
    - em **falha** (`ConnectionException`, HTTP de erro ou resposta sem `job_id`): marca o relatório como `failed` e encerra o Job de forma limpa (sem relançar), preservando as `legacy_metrics` já persistidas — impedindo Jobs "zumbis".
- **`app/Http/Controllers/ComparisonResultWebhookController.php`** (novo)
  - Controlador da rota `webhooks.comparison.result`. Recebe o resultado assíncrono do Solver e retorna `202 Accepted`. A persistência das `solver_metrics` e a transição para `completed` (via `AllocationEvaluatorService`) serão tratadas na issue dedicada ao webhook de comparação — este controlador existe primariamente para que a rota seja resolvível por `route()` no momento do disparo.
- **`routes/api.php`**
  - Registro de `POST /webhooks/comparison-result` → `webhooks.comparison.result`.
- **`tests/Feature/ProcessAlgorithmComparisonTest.php`**
  - `setUp()` configura `alocacao.solver.url`/`api_token`; helper `fakeSolverSuccess()` isola o fake do Solver (necessário porque o `Http::fake` do Laravel avalia todos os callbacks registrados, o que tornaria um fake default no `setUp` sempre vencedor sobre fakes de falha).
  - Testes existentes que disparam `handle()` até o fim agora chamam `fakeSolverSuccess()`, mantendo o status `processing`.
  - Novos testes:
    - `it_dispatches_solver_payload_with_comparison_webhook_url` — valida a injeção de `meta.webhook_url` e o `rooms` enviado;
    - `it_keeps_report_processing_and_caches_job_index_on_successful_dispatch` — status `processing` + índice `comparison:job:{jobId}`;
    - `it_marks_report_failed_when_solver_returns_http_error` — HTTP 500 → `failed` (legacy_metrics preservadas);
    - `it_marks_report_failed_when_solver_response_lacks_job_id` — resposta sem `job_id` → `failed`;
    - `it_marks_report_failed_when_solver_is_offline` — `ConnectionException` → `failed`;
    - `it_builds_solver_payload_from_base_state_preallocations` — pré-alocações do estado base chegam como `preassigned_room_id`.

## Critérios de Aceite (DoD)

- [x] O JSON gerado e enviado ao Python está estruturalmente válido e contém os webhooks customizados do módulo de Benchmarking.
- [x] Tratamento de *Exceptions* de requisição (HTTP 500 ou Timeout do solver) finalizando o status do benchmark com erro, impedindo Jobs "zumbis".

## Como testar

```bash
docker exec alocacao-app vendor/bin/phpunit --filter ProcessAlgorithmComparisonTest
```

Resultado: `OK (15 tests, 40 assertions)`.

## Notas

- As 6 faluras + 1 erro remanescentes na suíte completa (`DistributionFlowTest`, `AllocationStateTest`, `RoomAllocationPayloadBuilderTest`) são **pré-existentes no `master`** e não relacionadas a esta PR (verificadas em worktree limpa do `master`).
- O controlador `ComparisonResultWebhookController` é intencionalmente um stub; a lógica de avaliação das `solver_metrics` será implementada na issue dedicada ao webhook de comparação, conforme arquitetura (§4.4).
